### PR TITLE
chore: add CI and more just recipes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -123,5 +123,4 @@ jobs:
     - uses: actions/checkout@v2
     - name: rust toolchain
       run: rustup show
-    - name: cargo fmt
-      run: cargo fmt --check --workspace --all-features
+    - run: cargo fmt --check

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -92,6 +92,7 @@ jobs:
   loom:
     name: just loom
     needs: check # skip on commits that don't compile.
+    # TODO(eliza): this *should* only run if trickypipe changed...
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -101,7 +102,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: rust toolchain
       run: rustup show
-    - run: just loom --package tricky-pipe
+    - run: just loom
 
   # check that RustDoc builds
   docs:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,127 @@
+# Lovingly borrowed from mycelium's CI setup
+
+name: CI
+
+on:
+  # build all pushes to PR branches
+  pull_request:
+  # allow builds to be manually triggered from the UI.
+  workflow_dispatch:
+  # for github merge queue
+  merge_group:
+  # build all pushes to `main`
+  push:
+    branches: ["main"]
+
+env:
+  # disable incremental compilation.
+  #
+  # incremental compilation is useful as part of an edit-build-test-edit cycle,
+  # as it lets the compiler avoid recompiling code that hasn't changed. however,
+  # on CI, we're not making small edits; we're almost always building the entire
+  # project from scratch. thus, incremental compilation on CI actually
+  # introduces *additional* overhead to support making future builds
+  # faster...but no future builds will ever occur in any given CI environment.
+  #
+  # see https://matklad.github.io/2021/09/04/fast-rust-builds.html#ci-workflow
+  # for details.
+  CARGO_INCREMENTAL: 0
+  # allow more retries for network requests in cargo (downloading crates) and
+  # rustup (installing toolchains). this should help to reduce flaky CI failures
+  # from transient network timeouts or other issues.
+  CARGO_NET_RETRY: 10
+  CARGO_TERM_COLOR: always
+  RUSTUP_MAX_RETRIES: 10
+  # don't emit giant backtraces in the CI logs.
+  RUST_BACKTRACE: short
+
+jobs:
+  # dummy job to indicate everything has passed
+  all_systems_go:
+    name: "all systems go!"
+    runs-on: ubuntu-latest
+    needs:
+    - check
+    - clippy
+    - test
+    - loom
+    - docs
+    - fmt
+    steps:
+    - run: exit 0
+
+  # run `just check`
+  check:
+    name: just check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: olix0r/cargo-action-fmt@ee1ef42932e44794821dab57ef1bf7a73df8b21f
+    - uses: extractions/setup-just@v1
+    - uses: actions/checkout@v2
+    - name: rust toolchain
+      run: rustup show
+    - run: just check
+
+  # run `just clippy`
+  clippy:
+    name: just clippy
+    runs-on: ubuntu-latest
+    steps:
+        - uses: olix0r/cargo-action-fmt@ee1ef42932e44794821dab57ef1bf7a73df8b21f
+        - uses: extractions/setup-just@v1
+        - uses: actions/checkout@v2
+        - name: rust toolchain
+          run: rustup show
+        - run: just clippy
+
+  # run `just test`
+  test:
+    name: just test
+    needs: check # skip on commits that don't compile.
+    runs-on: ubuntu-latest
+    steps:
+    - name: install nextest
+      uses: taiki-e/install-action@nextest
+    - uses: extractions/setup-just@v1
+    - uses: actions/checkout@v2
+    - name: rust toolchain
+      run: rustup show
+    - run: just test
+
+  # run `just loom`
+  loom:
+    name: just loom
+    needs: check # skip on commits that don't compile.
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+    - name: install nextest
+      uses: taiki-e/install-action@nextest
+    - uses: extractions/setup-just@v1
+    - uses: actions/checkout@v2
+    - name: rust toolchain
+      run: rustup show
+    - run: just loom --package tricky-pipe
+
+  # check that RustDoc builds
+  docs:
+    name: just docs
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: rust toolchain
+      run: rustup show
+    - uses: olix0r/cargo-action-fmt@ee1ef42932e44794821dab57ef1bf7a73df8b21f
+    - uses: extractions/setup-just@v1
+    - run: just docs
+
+  # check cargo fmt
+  fmt:
+    name: cargo fmt
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: rust toolchain
+      run: rustup show
+    - name: cargo fmt
+      run: cargo fmt --check --workspace --all-features

--- a/justfile
+++ b/justfile
@@ -64,7 +64,7 @@ export LOOM_MAX_PREEMPTIONS := env_var_or_default("LOOM_MAX_PREEMPTIONS", "2")
 export RUSTDOCFLAGS := env_var_or_default("RUSTDOCFLAGS", "--cfg docsrs")
 
 # run Loom tests
-loom *NEXTEST_ARGS:
+loom *NEXTEST_ARGS="--package tricky-pipe --all-features":
     RUSTFLAGS=" --cfg loom --cfg debug_assertions" \
         {{ _cargo }} {{ _testcmd }} --release {{ NEXTEST_ARGS }}
 

--- a/justfile
+++ b/justfile
@@ -9,6 +9,8 @@ Available variables:
     no-nextest              # disables cargo nextest (use cargo test) instead.
     profile                 # configures what Cargo profile (release or debug)
                             # to use for builds.
+
+Environment variables and defaults:
     LOOM_LOG='debug'        # sets the log level for Loom tests.
     LOOM_LOCATION='true'    # enables/disables location tracking in Loom tests.
 
@@ -55,11 +57,30 @@ default:
     @just --list
 
 
+# passes through the LOOM_LOG env var to loom.
 export LOOM_LOG := env_var_or_default("LOOM_LOG", "debug")
 export LOOM_LOCATION := env_var_or_default("LOOM_LOCATION", "true")
 export LOOM_MAX_PREEMPTIONS := env_var_or_default("LOOM_MAX_PREEMPTIONS", "2")
+export RUSTDOCFLAGS := env_var_or_default("RUSTDOCFLAGS", "--cfg docsrs")
 
 # run Loom tests
-loom *ARGS:
+loom *NEXTEST_ARGS:
     RUSTFLAGS=" --cfg loom --cfg debug_assertions" \
-        {{ _cargo }} {{ _testcmd }} --release {{ ARGS }}
+        {{ _cargo }} {{ _testcmd }} --release {{ NEXTEST_ARGS }}
+
+# run cargo check
+check *CARGO_ARGS="--workspace --all-features --all-targets":
+    {{ _cargo }} check {{ CARGO_ARGS }} {{ _fmt_check_doc }}
+
+# run cargo clippy
+clippy *CLIPPY_ARGS="--workspace --all-features --all-targets":
+    {{ _cargo }} clippy {{ CLIPPY_ARGS }} {{ _fmt_check_doc }}
+
+# run cargo test
+test *NEXTEST_ARGS="--workspace --all-features":
+    {{ _cargo }} {{ _testcmd }} {{ NEXTEST_ARGS }}
+    {{ _cargo }} test --doc {{ NEXTEST_ARGS }}
+
+# build RustDoc
+docs *RUSTDOC_ARGS="--workspace":
+    {{ _cargo }} doc --no-deps --all-features {{ RUSTDOC_ARGS }}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,8 @@
 [toolchain]
 channel = "nightly-2023-08-08"
+profile = "minimal"
+components = [
+    "clippy",
+    "rustfmt",
+    "rust-src",
+]

--- a/source/mgnp-pitch/src/lib.rs
+++ b/source/mgnp-pitch/src/lib.rs
@@ -29,6 +29,4 @@ enum IdentityKind {
     Name(heapless::String<32>),
 }
 
-struct Registry {
-
-}
+struct Registry {}

--- a/source/plugtail/src/lib.rs
+++ b/source/plugtail/src/lib.rs
@@ -57,12 +57,12 @@ pub struct PlugTail<H, T> {
 pub mod alloc {
     extern crate alloc;
 
+    use super::*;
+    use alloc::alloc::{dealloc, Layout};
     use core::{
         ptr::{addr_of, addr_of_mut, drop_in_place, NonNull},
         sync::atomic::{AtomicUsize, Ordering},
     };
-    use alloc::alloc::{dealloc, Layout};
-    use super::*;
 
     /// An Arc-like heap allocated Pluggable
     pub struct ArcPlugTail<H, T>
@@ -72,8 +72,8 @@ pub mod alloc {
         pt: NonNull<PlugTail<ArcHdr<H>, T>>,
     }
 
-    unsafe impl<H: Send + BodyDrop<Item = T>, T: Send> Send for ArcPlugTail<H, T> { }
-    unsafe impl<H: Send + BodyDrop<Item = T>, T: Send> Sync for ArcPlugTail<H, T> { }
+    unsafe impl<H: Send + BodyDrop<Item = T>, T: Send> Send for ArcPlugTail<H, T> {}
+    unsafe impl<H: Send + BodyDrop<Item = T>, T: Send> Sync for ArcPlugTail<H, T> {}
 
     #[repr(C)]
     pub struct ArcHdr<H> {
@@ -177,7 +177,9 @@ pub mod alloc {
 
         unsafe fn unleak(ptr: *const ()) -> Self {
             // welp
-            Self { pt: NonNull::new_unchecked(ptr.cast_mut().cast()) }
+            Self {
+                pt: NonNull::new_unchecked(ptr.cast_mut().cast()),
+            }
         }
     }
 }
@@ -193,8 +195,8 @@ pub struct StaticPlugTail<H, T, const N: usize> {
 
 // TODO: should StaticPlugTail have any kind of blanket impl for
 // Send or Sync?
-unsafe impl<H: Send, T: Send, const N: usize> Send for StaticPlugTail<H, T, N> { }
-unsafe impl<H: Send, T: Send, const N: usize> Sync for StaticPlugTail<H, T, N> { }
+unsafe impl<H: Send, T: Send, const N: usize> Send for StaticPlugTail<H, T, N> {}
+unsafe impl<H: Send, T: Send, const N: usize> Sync for StaticPlugTail<H, T, N> {}
 
 impl<H, T, const N: usize> StaticPlugTail<H, T, N> {
     const ONE: UnsafeCell<MaybeUninit<T>> = UnsafeCell::new(MaybeUninit::uninit());
@@ -208,8 +210,7 @@ impl<H, T, const N: usize> StaticPlugTail<H, T, N> {
 
     // TODO: Is there any way we could make this not UC<MU<T>> and instead pass
     // a [T; N]? That would be a much nicer API...
-    pub const fn new(hdr: H, val: [UnsafeCell<MaybeUninit<T>>; N]) -> Self
-    {
+    pub const fn new(hdr: H, val: [UnsafeCell<MaybeUninit<T>>; N]) -> Self {
         Self {
             pt: PlugTail { hdr, tail: [] },
             tfr: val,

--- a/source/tricky-pipe/src/lib.rs
+++ b/source/tricky-pipe/src/lib.rs
@@ -1067,5 +1067,4 @@ impl<T> DerefMut for Permit<'_, T> {
     }
 }
 
-
 pub(crate) mod loom;


### PR DESCRIPTION
This branch adds a quick GitHub Actions CI configuration & a bunch more `just` recipes for running those CI steps. 

In the future, it would probably be nice to only run the slowish `loom` tests when tricky-pipe changes.