### PR TITLE
feat(tricky-pipe): initial bidirectional channel implementation

### DIFF
--- a/source/tricky-pipe/Cargo.toml
+++ b/source/tricky-pipe/Cargo.toml
@@ -27,6 +27,7 @@ alloc = ["postcard/alloc"]
 maitake-sync = "0.1.0"
 portable-atomic = "1.4.3"
 mnemos-bitslab = { git = "https://github.com/tosc-rs/mnemos", branch = "eliza/bitslab-loom" }
+futures = { version = "0.3", features = ["async-await"], default-features = false }
 
 [dependencies.postcard]
 version = "1.0.7"

--- a/source/tricky-pipe/src/arc_impl.rs
+++ b/source/tricky-pipe/src/arc_impl.rs
@@ -46,6 +46,7 @@ impl<T: 'static> TrickyPipe<T> {
         get_elems: Self::get_elems,
         clone: Self::erased_clone,
         drop: Self::erased_drop,
+        type_name: core::any::type_name::<T>,
     };
 
     fn erased(&self) -> ErasedPipe {

--- a/source/tricky-pipe/src/bidi.rs
+++ b/source/tricky-pipe/src/bidi.rs
@@ -1,0 +1,54 @@
+#![allow(missing_docs)]
+use super::*;
+use futures::FutureExt;
+
+pub struct BiDi<In: 'static, Out: 'static = In> {
+    tx: Sender<Out>,
+    rx: Receiver<In>,
+}
+
+pub struct SerBiDi {
+    tx: DeserSender,
+    rx: SerReceiver,
+}
+
+pub enum Event<In, Out> {
+    Recv(In),
+    SendReady(Out),
+}
+
+impl<In, Out> BiDi<In, Out>
+where
+    In: 'static,
+    Out: 'static,
+{
+    pub async fn wait(&self) -> Option<Event<In, Permit<'_, Out>>> {
+        futures::select_biased! {
+            res = self.tx.reserve().fuse() => {
+                match res {
+                    Ok(permit) => Some(Event::SendReady(permit)),
+                    Err(_) => self.rx.recv().await.map(Event::Recv),
+                }
+            }
+            recv = self.rx.recv().fuse() => {
+                recv.map(Event::Recv)
+            }
+        }
+    }
+}
+
+impl SerBiDi {
+    pub async fn wait(&self) -> Option<Event<SerRecvRef<'_>, SerPermit<'_>>> {
+        futures::select_biased! {
+            res = self.tx.reserve().fuse() => {
+                match res {
+                    Ok(permit) => Some(Event::SendReady(permit)),
+                    Err(_) => self.rx.recv().await.map(Event::Recv),
+                }
+            }
+            recv = self.rx.recv().fuse() => {
+                recv.map(Event::Recv)
+            }
+        }
+    }
+}

--- a/source/tricky-pipe/src/bidi.rs
+++ b/source/tricky-pipe/src/bidi.rs
@@ -22,6 +22,17 @@ where
     In: 'static,
     Out: 'static,
 {
+    #[must_use]
+    pub fn new(tx: Sender<Out>, rx: Receiver<In>) -> Self {
+        Self { tx, rx }
+    }
+
+    #[must_use]
+    pub fn split(self) -> (Sender<Out>, Receiver<In>) {
+        (self.tx, self.rx)
+    }
+
+    #[must_use]
     pub async fn wait(&self) -> Option<Event<In, Permit<'_, Out>>> {
         futures::select_biased! {
             res = self.tx.reserve().fuse() => {
@@ -35,9 +46,68 @@ where
             }
         }
     }
+
+    /// Borrows the **send half** of this bidirectional channel.
+    ///
+    /// This may be used to call methods such as [`Sender::send`], [`Sender::reserve`],
+    /// [`Sender::try_reserve`], [`Sender::capacity`], et cetera, on the send
+    /// half of the channel.
+    #[must_use]
+    pub fn tx(&self) -> &Sender<Out> {
+        &self.tx
+    }
+
+    /// Borrows the **receive half** of this bidirectional channel.
+    ///
+    /// This may be used to call methods such as [`Receiver::recv`],
+    /// [`Receiver::try_recv`], [`Receiver::capacity`], et cetera, on the
+    /// receive half of the channel.
+    #[must_use]
+    pub fn rx(&self) -> &Receiver<In> {
+        &self.rx
+    }
+
+    /// Returns `true` if **both halves** of this bidirectional channel are
+    /// empty.
+    ///
+    /// This method returns `true` if and only if *both the send and receive
+    /// halves* of this channel are empty. To check if only one the send or
+    /// receive half is empty, use
+    /// [`self.tx()`]`.`[`is_empty()`](Sender::is_empty) or
+    /// [`self.rx()`]`.`[`is_empty()`](Receiver::is_empty), respectively.
+    #[inline]
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.tx.is_empty() && self.rx.is_empty()
+    }
+
+    /// Returns `true` if **both halves** of this bidirectional channel are
+    /// full.
+    ///
+    /// This method returns `true` if and only if *both the send and receive
+    /// halves* of this channel are full. To check if only one the send or
+    /// receive half is full, use
+    /// [`self.tx()`]`.`[`is_full()`](Sender::is_full) or
+    /// [`self.rx()`]`.`[`is_full()`](Receiver::is_full), respectively.
+    #[inline]
+    #[must_use]
+    pub fn is_full(&self) -> bool {
+        self.tx.is_full() && self.rx.is_full()
+    }
 }
 
 impl SerBiDi {
+    #[must_use]
+    pub fn new(tx: DeserSender, rx: SerReceiver) -> Self {
+        Self { tx, rx }
+    }
+
+    #[must_use]
+    pub fn split(self) -> (DeserSender, SerReceiver) {
+        (self.tx, self.rx)
+    }
+
+    #[must_use]
     pub async fn wait(&self) -> Option<Event<SerRecvRef<'_>, SerPermit<'_>>> {
         futures::select_biased! {
             res = self.tx.reserve().fuse() => {
@@ -50,5 +120,53 @@ impl SerBiDi {
                 recv.map(Event::Recv)
             }
         }
+    }
+
+    /// Borrows the **send half** of this bidirectional channel.
+    ///
+    /// This may be used to call methods such as [`DeserSender::reserve`],
+    /// [`DeserSender::try_reserve`], [`DeserSender::capacity`], et cetera, on
+    /// the send half of the channel.
+    #[must_use]
+    pub fn tx(&self) -> &DeserSender {
+        &self.tx
+    }
+
+    /// Borrows the **receive half** of this bidirectional channel.
+    ///
+    /// This may be used to call methods such as [`SerReceiver::recv`],
+    /// [`SerReceiver::try_recv`], [`SerReceiver::capacity`], et cetera, on the
+    /// receive half of the channel.
+    #[must_use]
+    pub fn rx(&self) -> &SerReceiver {
+        &self.rx
+    }
+
+    /// Returns `true` if **both halves** of this bidirectional channel are
+    /// empty.
+    ///
+    /// This method returns `true` if and only if *both the send and receive
+    /// halves* of this channel are empty. To check if only one the send or
+    /// receive half is empty, use
+    /// [`self.tx()`]`.`[`is_empty()`](DeserSender::is_empty) or
+    /// [`self.rx()`]`.`[`is_empty()`](SerReceiver::is_empty), respectively.
+    #[inline]
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.tx.is_empty() && self.rx.is_empty()
+    }
+
+    /// Returns `true` if **both halves** of this bidirectional channel are
+    /// full.
+    ///
+    /// This method returns `true` if and only if *both the send and receive
+    /// halves* of this channel are full. To check if only one the send or
+    /// receive half is full, use
+    /// [`self.tx()`]`.`[`is_full()`](DeserSender::is_full) or
+    /// [`self.rx()`]`.`[`is_full()`](SerReceiver::is_full), respectively.
+    #[inline]
+    #[must_use]
+    pub fn is_full(&self) -> bool {
+        self.tx.is_full() && self.rx.is_full()
     }
 }

--- a/source/tricky-pipe/src/bidi.rs
+++ b/source/tricky-pipe/src/bidi.rs
@@ -29,6 +29,8 @@ pub struct SerBiDi {
 }
 
 /// Events returned by [`BiDi::wait`] and [`SerBiDi::wait`].
+#[derive(Debug)]
+#[must_use]
 pub enum Event<In, Out> {
     /// A message was received from the remote peer.
     Recv(In),
@@ -118,6 +120,22 @@ where
     }
 }
 
+impl<In, Out> fmt::Debug for BiDi<In, Out>
+where
+    In: 'static,
+    Out: 'static,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self { tx, rx } = self;
+        f.debug_struct("BiDi")
+            .field("tx", tx)
+            .field("rx", rx)
+            .finish()
+    }
+}
+
+// === impl SerBiDi ===
+
 impl SerBiDi {
     /// Constructs a new `SerBiDi` from a [`DesererSender`] and a [`SerReceiver`].
     pub fn from_pair(tx: DeserSender, rx: SerReceiver) -> Self {
@@ -193,5 +211,15 @@ impl SerBiDi {
     #[must_use]
     pub fn is_full(&self) -> bool {
         self.tx.is_full() && self.rx.is_full()
+    }
+}
+
+impl fmt::Debug for SerBiDi {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self { tx, rx } = self;
+        f.debug_struct("SerBiDi")
+            .field("tx", tx)
+            .field("rx", rx)
+            .finish()
     }
 }

--- a/source/tricky-pipe/src/lib.rs
+++ b/source/tricky-pipe/src/lib.rs
@@ -22,6 +22,7 @@ use core::{
     ptr,
 };
 use serde::{de::DeserializeOwned, Serialize};
+pub mod bidi;
 
 #[cfg(not(test))]
 macro_rules! test_dbg {

--- a/source/tricky-pipe/src/lib.rs
+++ b/source/tricky-pipe/src/lib.rs
@@ -37,7 +37,7 @@ macro_rules! test_dbg {
         match $x {
             x => {
                 const EXPR: &str = stringify!($x);
-                tracing::event!(tracing::Level::DEBUG, { EXPR } = ?x);
+                tracing::event!(tracing::Level::DEBUG, { EXPR } = ?format_args!("{x:#?}"));
                 x
             }
         }
@@ -334,6 +334,12 @@ impl<T> Drop for Receiver<T> {
     }
 }
 
+impl<T> fmt::Debug for Receiver<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.pipe.fmt_into(&mut f.debug_struct("Receiver"))
+    }
+}
+
 // === impl SerReceiver ===
 
 impl SerReceiver {
@@ -478,6 +484,12 @@ impl SerReceiver {
 impl Drop for SerReceiver {
     fn drop(&mut self) {
         self.pipe.core().close_rx();
+    }
+}
+
+impl fmt::Debug for SerReceiver {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.pipe.fmt_into(&mut f.debug_struct("SerReceiver"))
     }
 }
 
@@ -752,6 +764,11 @@ impl Drop for DeserSender {
     }
 }
 
+impl fmt::Debug for DeserSender {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.pipe.fmt_into(&mut f.debug_struct("DeserSender"))
+    }
+}
 // === impl SerPermit ===
 
 impl SerPermit<'_> {
@@ -783,6 +800,7 @@ impl SerPermit<'_> {
         Ok(())
     }
 }
+
 // === impl Sender ===
 
 impl<T> Sender<T> {
@@ -1009,6 +1027,13 @@ impl<T: 'static> Drop for Sender<T> {
     }
 }
 
+impl<T: 'static> fmt::Debug for Sender<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.pipe.fmt_into(&mut f.debug_struct("Sender"))
+    }
+}
+
+// === impl Permit ===
 impl<T> Permit<'_, T> {
     /// Write the given value into the [Permit], and send it
     ///

--- a/source/tricky-pipe/src/static_impl.rs
+++ b/source/tricky-pipe/src/static_impl.rs
@@ -38,6 +38,7 @@ impl<T: 'static, const CAPACITY: usize> StaticTrickyPipe<T, CAPACITY> {
         get_elems: Self::get_elems,
         clone: Self::erased_clone,
         drop: Self::erased_drop,
+        type_name: core::any::type_name::<T>,
     };
 
     fn erased(&'static self) -> ErasedPipe {

--- a/source/tricky-pipe/src/tests.rs
+++ b/source/tricky-pipe/src/tests.rs
@@ -41,8 +41,8 @@ mod single_threaded {
     fn normal_smoke() {
         loom::model(|| {
             let chan = TrickyPipe::<UnSerStruct>::new(4);
-            let tx = chan.sender();
-            let rx = chan.receiver().unwrap();
+            let tx = test_dbg!(chan.sender());
+            let rx = test_dbg!(chan.receiver().unwrap());
             tx.try_reserve().unwrap().send(UnSerStruct {
                 a: 240,
                 b: -6_000,
@@ -100,8 +100,8 @@ mod single_threaded {
     fn normal_closed_rx() {
         loom::model(|| {
             let chan = TrickyPipe::<UnSerStruct>::new(4);
-            let tx = chan.sender();
-            let rx = chan.receiver().unwrap();
+            let tx = test_dbg!(chan.sender());
+            let rx = test_dbg!(chan.receiver().unwrap());
             drop(rx);
             assert_eq!(tx.try_reserve().unwrap_err(), TrySendError::Closed(()),);
         });
@@ -111,8 +111,8 @@ mod single_threaded {
     fn normal_closed_tx() {
         loom::model(|| {
             let chan = TrickyPipe::<UnSerStruct>::new(4);
-            let tx = chan.sender();
-            let rx = chan.receiver().unwrap();
+            let tx = test_dbg!(chan.sender());
+            let rx = test_dbg!(chan.receiver().unwrap());
             drop(chan);
             drop(tx);
             assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Closed,);
@@ -123,9 +123,9 @@ mod single_threaded {
     fn normal_closed_cloned_tx() {
         loom::model(|| {
             let chan = TrickyPipe::<UnSerStruct>::new(4);
-            let tx1 = chan.sender();
-            let tx2 = tx1.clone();
-            let rx = chan.receiver().unwrap();
+            let tx1 = test_dbg!(chan.sender());
+            let tx2 = test_dbg!(tx1.clone());
+            let rx = test_dbg!(chan.receiver().unwrap());
             drop(chan);
             drop(tx1);
             drop(tx2);
@@ -137,8 +137,8 @@ mod single_threaded {
     fn ser_smoke() {
         loom::model(|| {
             let chan = TrickyPipe::<SerStruct>::new(4);
-            let tx = chan.sender();
-            let rx = chan.ser_receiver().unwrap();
+            let tx = test_dbg!(chan.sender());
+            let rx = test_dbg!(chan.ser_receiver()).unwrap();
             tx.try_reserve().unwrap().send(SerStruct {
                 a: 240,
                 b: -6_000,
@@ -183,8 +183,8 @@ mod single_threaded {
     fn ser_closed_rx() {
         loom::model(|| {
             let chan = TrickyPipe::<SerStruct>::new(4);
-            let tx = chan.sender();
-            let rx = chan.ser_receiver().unwrap();
+            let tx = test_dbg!(chan.sender());
+            let rx = test_dbg!(chan.ser_receiver()).unwrap();
             drop(rx);
             assert_eq!(tx.try_reserve().unwrap_err(), TrySendError::Closed(()));
         });
@@ -194,8 +194,8 @@ mod single_threaded {
     fn ser_closed_tx() {
         loom::model(|| {
             let chan = TrickyPipe::<SerStruct>::new(4);
-            let tx = chan.sender();
-            let rx = chan.ser_receiver().unwrap();
+            let tx = test_dbg!(chan.sender());
+            let rx = test_dbg!(chan.ser_receiver()).unwrap();
             drop(chan);
             drop(tx);
             assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Closed);
@@ -208,7 +208,7 @@ mod single_threaded {
             let chan = TrickyPipe::<SerStruct>::new(4);
             let tx1 = chan.sender();
             let tx2 = tx1.clone();
-            let rx = chan.ser_receiver().unwrap();
+            let rx = test_dbg!(chan.ser_receiver()).unwrap();
             drop(chan);
             drop(tx1);
             drop(tx2);
@@ -220,8 +220,8 @@ mod single_threaded {
     fn ser_ref_smoke() {
         loom::model(|| {
             let chan = TrickyPipe::<SerStruct>::new(4);
-            let tx = chan.sender();
-            let rx = chan.ser_receiver().unwrap();
+            let tx = test_dbg!(chan.sender());
+            let rx = test_dbg!(chan.ser_receiver()).unwrap();
             tx.try_reserve().unwrap().send(SerStruct {
                 a: 240,
                 b: -6_000,
@@ -266,8 +266,8 @@ mod single_threaded {
     fn deser_smoke() {
         loom::model(|| {
             let chan = TrickyPipe::<DeStruct>::new(4);
-            let tx = chan.deser_sender();
-            let rx = chan.receiver().unwrap();
+            let tx = test_dbg!(chan.deser_sender());
+            let rx = test_dbg!(chan.receiver()).unwrap();
             tx.try_send([240, 223, 93, 160, 141, 6, 5, 104, 101, 108, 108, 111])
                 .unwrap();
 
@@ -313,8 +313,8 @@ mod single_threaded {
     fn deser_closed_rx() {
         loom::model(|| {
             let chan = TrickyPipe::<DeStruct>::new(4);
-            let tx = chan.deser_sender();
-            let rx = chan.receiver().unwrap();
+            let tx = test_dbg!(chan.deser_sender());
+            let rx = test_dbg!(chan.receiver()).unwrap();
             drop(chan);
             drop(rx);
             let res = tx.try_send([240, 223, 93, 160, 141, 6, 5, 104, 101, 108, 108, 111]);
@@ -329,8 +329,8 @@ mod single_threaded {
     fn deser_closed_tx() {
         loom::model(|| {
             let chan = TrickyPipe::<DeStruct>::new(4);
-            let tx = chan.deser_sender();
-            let rx = chan.receiver().unwrap();
+            let tx = test_dbg!(chan.deser_sender());
+            let rx = test_dbg!(chan.receiver()).unwrap();
             drop(chan);
             drop(tx);
             assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Closed);
@@ -341,9 +341,9 @@ mod single_threaded {
     fn deser_closed_cloned_tx() {
         loom::model(|| {
             let chan = TrickyPipe::<DeStruct>::new(4);
-            let tx1 = chan.deser_sender();
+            let tx1 = test_dbg!(chan.deser_sender());
             let tx2 = tx1.clone();
-            let rx = chan.receiver().unwrap();
+            let rx = test_dbg!(chan.receiver()).unwrap();
             drop(chan);
             drop(tx1);
             drop(tx2);
@@ -358,8 +358,8 @@ mod single_threaded {
         // it works anyway i guess...
         loom::model(|| {
             let chan = TrickyPipe::<SerDeStruct>::new(4);
-            let tx = chan.deser_sender();
-            let rx = chan.ser_receiver().unwrap();
+            let tx = test_dbg!(chan.deser_sender());
+            let rx = test_dbg!(chan.ser_receiver()).unwrap();
             const MSG_ONE: &[u8] = &[240, 223, 93, 160, 141, 6, 5, 104, 101, 108, 108, 111];
             const MSG_TWO: &[u8] = &[20, 255, 124, 192, 154, 12, 6, 103, 114, 101, 101, 116, 115];
             const MSG_THREE: &[u8] = &[100, 207, 15, 224, 167, 18, 5, 111, 104, 32, 109, 121];
@@ -388,8 +388,8 @@ fn elements_dropped() {
     loom::model(|| {
         let chan = TrickyPipe::<loom::alloc::Track<usize>>::new(4);
 
-        let rx = chan.receiver().expect("can't get rx");
-        let tx = chan.sender();
+        let rx = test_dbg!(chan.receiver()).expect("can't get rx");
+        let tx = test_dbg!(chan.sender());
         let thread = thread::spawn(move || {
             tx.try_reserve()
                 .expect("reserve 1")
@@ -420,8 +420,8 @@ fn spsc_try_send_in_capacity() {
     loom::model(|| {
         let (rx, tx) = {
             let chan = TrickyPipe::<loom::alloc::Track<usize>>::new(SENDS as u8);
-            let rx = chan.receiver().expect("can't get rx");
-            let tx = chan.sender();
+            let rx = test_dbg!(chan.receiver()).expect("can't get rx");
+            let tx = test_dbg!(chan.sender());
             (rx, tx)
         };
         let thread = thread::spawn(move || {
@@ -452,8 +452,8 @@ fn spsc_send() {
     loom::model(|| {
         let (rx, tx) = {
             let chan = TrickyPipe::<loom::alloc::Track<usize>>::new((SENDS / 2) as u8);
-            let rx = chan.receiver().expect("can't get rx");
-            let tx = chan.sender();
+            let rx = test_dbg!(chan.receiver()).expect("can't get rx");
+            let tx = test_dbg!(chan.sender());
             (rx, tx)
         };
 
@@ -483,7 +483,7 @@ fn mpsc_send() {
     loom::model(|| {
         let chan = TrickyPipe::<loom::alloc::Track<usize>>::new(CAPACITY);
 
-        let rx = chan.receiver().expect("can't get rx");
+        let rx = test_dbg!(chan.receiver()).expect("can't get rx");
         let tx1 = chan.sender();
         let tx2 = chan.sender();
         // drop the channel now so that the channel can be tx-closed.


### PR DESCRIPTION
This branch adds an initial implementation of bidirectional channels based on a `Sender`/`Receiver` pair to the `tricky-pipe` crate.