### PR TITLE
feat(tricky-pipe): consistent `oneshot::Receiver` API

### DIFF
--- a/source/tricky-pipe/src/oneshot.rs
+++ b/source/tricky-pipe/src/oneshot.rs
@@ -135,9 +135,8 @@ use alloc::sync::Arc;
 /// producers can be live at any given time
 ///
 /// A [`Receiver`]`<T>` can be used to hand out single-use [`Sender`] or
-/// [`DeserSender`] handles, using the [`Receiver::sender`],
-/// [`Receiver::deser_sender`], [`Receiver::static_sender`] and
-/// [`Receiver::deser_static_sender`] methods. Each sender handle can be used
+/// [`DeserSender`] handles, using the [`Receiver::sender`] and
+/// [`Receiver::deser_sender`] methods. Each sender handle can be used once
 /// to send a single message to the receiver.
 ///
 /// See the [module-level documentation](../#reusing-a-one-shot-channel) for
@@ -160,8 +159,7 @@ pub struct Receiver<T> {
 /// be created. Dropping this [`Sender`] releases the reservation on the
 /// channel, allowing a new [`Sender`] or [`DeserSender`] to be created.
 ///
-/// [`Sender`]s are constructed using the [`Receiver::sender`] and
-/// [`Receiver::static_sender`] methods.
+/// [`Sender`]s are constructed using the [`Receiver::sender`]  method.
 #[must_use = "a `Sender` does nothing unless used to send a message"]
 pub struct Sender<T> {
     chan: *const Oneshot<T>,
@@ -182,8 +180,8 @@ pub struct Sender<T> {
 /// may be created. Dropping this [`DeserSender`] releases the reservation on the
 /// channel, allowing a new [`Sender`] or [`DeserSender`] to be created.
 ///
-/// [`DeserSender`]s are constructed using the [`Receiver::deser_sender`] and
-/// [`Receiver::deser_static_sender`] methods.
+/// [`DeserSender`]s are constructed using the [`Receiver::deser_sender`]
+/// method.
 #[must_use = "a `DeserSender` does nothing unless used to receive a message"]
 pub struct DeserSender {
     chan: *const Oneshot<()>,
@@ -210,26 +208,22 @@ pub enum RecvError {
     Closed,
 }
 
-/// Errors returned by [`Receiver::sender`], [`Receiver::deser_sender`],
-/// [`Receiver::static_sender`], and [`Receiver::deser_static_sender`].
+/// Errors returned by [`Receiver::sender`] and [`Receiver::deser_sender`].
 #[derive(Debug, Eq, PartialEq)]
 pub enum SenderError {
     /// A [`Sender`] or [`DeserSender`] already exists, so a new one may not be
     /// created at this time.
     ///
     /// When the currently active [`Sender`] or [`DeserSender`] is dropped, the
-    /// next call to one of the [`Receiver::sender`],
-    /// [`Receiver::deser_sender`], [`Receiver::static_sender`], or
-    /// [`Receiver::deser_static_sender`] methods on this [`Receiver`] will
-    /// succeed.
+    /// next call to the [`Receiver::sender`] or [`Receiver::deser_sender`]
+    /// methods on this [`Receiver`] will succeed.
     SenderAlreadyActive,
     /// The [`Receiver`] has closed the channel using the
     /// [`close`](Receiver::close) method, so no senders can be created.
     ///
-    /// If this error is returned, the [`Receiver::sender`],
-    /// [`Receiver::deser_sender`], [`Receiver::static_sender`], and
-    /// [`Receiver::deser_static_sender`] methods on this [`Receiver`] will
-    /// *never* return [`Ok`] again.
+    /// If this error is returned, the [`Receiver::sender`] and
+    /// [`Receiver::deser_sender`] methods on this [`Receiver`] will *never*
+    /// return [`Ok`] again.
     Closed,
 }
 

--- a/source/tricky-pipe/src/oneshot.rs
+++ b/source/tricky-pipe/src/oneshot.rs
@@ -621,6 +621,16 @@ impl<T> Default for Receiver<T> {
     }
 }
 
+impl<T> Drop for Receiver<T> {
+    fn drop(&mut self) {
+        unsafe {
+            // decrement the ref count, if this sender was constructed from an
+            // `Arc<Oneshot>`.
+            (self.drop)(self.chan)
+        }
+    }
+}
+
 unsafe impl<T: Send> Send for Receiver<T> {}
 unsafe impl<T: Send> Sync for Receiver<T> {}
 

--- a/source/tricky-pipe/src/oneshot.rs
+++ b/source/tricky-pipe/src/oneshot.rs
@@ -124,8 +124,10 @@ use alloc::sync::Arc;
 #[repr(C)]
 #[must_use = "a `Receiver` does nothing unless used to receive a message"]
 pub struct Receiver<T> {
-    head: Header,
-    cell: UnsafeCell<MaybeUninit<T>>,
+    chan: *const Oneshot<T>,
+    drop_erased: unsafe fn(*const Oneshot<()>),
+    drop: unsafe fn(*const Oneshot<T>),
+    clone: unsafe fn(*const Oneshot<T>),
 }
 
 /// Sends a single message to the corresponding [`Receiver`].
@@ -141,8 +143,8 @@ pub struct Receiver<T> {
 /// [`Receiver::static_sender`] methods.
 #[must_use = "a `Sender` does nothing unless used to send a message"]
 pub struct Sender<T> {
-    chan: *const Receiver<T>,
-    drop: unsafe fn(*const Receiver<T>),
+    chan: *const Oneshot<T>,
+    drop: unsafe fn(*const Oneshot<T>),
     sent: bool,
 }
 
@@ -163,8 +165,8 @@ pub struct Sender<T> {
 /// [`Receiver::deser_static_sender`] methods.
 #[must_use = "a `DeserSender` does nothing unless used to receive a message"]
 pub struct DeserSender {
-    chan: *const Receiver<()>,
-    drop: unsafe fn(*const Receiver<()>),
+    chan: *const Oneshot<()>,
+    drop: unsafe fn(*const Oneshot<()>),
     vtable: &'static DeserVtable,
     sent: bool,
 }
@@ -233,6 +235,12 @@ pub enum DeserSendError {
     Closed,
 }
 
+#[repr(C)]
+pub struct Oneshot<T> {
+    head: Header,
+    cell: UnsafeCell<MaybeUninit<T>>,
+}
+
 #[derive(Debug)]
 struct Header {
     state: AtomicU8,
@@ -247,87 +255,72 @@ struct DeserVtable {
 }
 
 /// Not waiting for anything.
-const IDLE: u8 = 0;
+const HAS_RX: u8 = 1 << 0;
 /// A Sender has been created, but no writes have begun yet
-const HAS_TX: u8 = 0b0001;
+const HAS_TX: u8 = 1 << 1;
 /// The receiver is waiting for a value.
-const RX_WAITING: u8 = 0b0010;
+const RX_WAITING: u8 = 1 << 2;
 // A value has been sent.
-const SENT: u8 = 0b0100;
+const SENT: u8 = 1 << 3;
 /// The Oneshot has been manually closed or dropped.
-const CLOSED: u8 = 0b1000;
+const CLOSED: u8 = 1 << 4;
 
-impl<T> Receiver<T> {
-    /// Returns a new one-shot channel receiver.
-    ///
-    /// In order to construct a [`Sender`] or [`DeserSender`], this value must
-    /// either be stored in a `static` or wrapped in an [`Arc`]. See the
-    /// [module-level documentation](../#heap-and-static-storage) on storing the
-    /// shared state for details.
-    ///
-    /// # Examples
-    ///
-    /// Storing the `Receiver` in a `static`:
-    ///
-    /// ```
-    /// use tricky_pipe::oneshot;
-    ///
-    /// static RX: oneshot::Receiver<usize> = oneshot::Receiver::new();
-    /// # #[tokio::main(flavor = "current_thread")] async fn main() {
-    ///
-    /// // because the `Receiver` is stored in a `static`, we can create a
-    /// // `Sender` using the `static_sender` method:
-    /// let tx = RX.static_sender().await.unwrap();
-    ///
-    /// tx.send(1).unwrap();
-    /// assert_eq!(RX.recv().await, Ok(1));
-    /// # }
-    /// ```
-    ///
-    /// Storing the `Receiver` in an [`Arc`]:
-    ///
-    /// ```
-    /// use tricky_pipe::oneshot;
-    /// use std::sync::Arc;
-    ///
-    /// # #[tokio::main(flavor = "current_thread")] async fn main() {
-    /// let rx = Arc::new(oneshot::Receiver::new());
-    ///
-    /// // because the `Receiver` is stored in an `Arc`, we can create a
-    /// // `Sender` using the `sender` method:
-    /// let tx = rx.sender().await.unwrap();
-    ///
-    /// tx.send(1).unwrap();
-    /// assert_eq!(rx.recv().await, Ok(1));
-    /// # }
-    /// ```
+impl<T> Oneshot<T> {
     #[cfg(not(loom))]
     pub const fn new() -> Self {
         Self {
             head: Header {
-                state: AtomicU8::new(IDLE),
+                state: AtomicU8::new(0),
                 wait: WaitCell::new(),
             },
-
             cell: UnsafeCell::new(MaybeUninit::uninit()),
         }
     }
 
-    /// Returns a new one-shot channel receiver.
-    ///
-    /// In order to construct a [`Sender`] or [`DeserSender`], this value must
-    /// be wrapped in an [`Arc`]. See the [module-level
-    /// documentation](../#heap-and-static-storage) on storing the shared state
-    /// for details.
-    #[cfg(loom)]
+    pub fn static_receiver(&'static self) -> Option<Receiver<T>> {
+        self.head
+            .state
+            .compare_exchange(0, HAS_RX, AcqRel, Acquire)
+            .ok()?;
+        Some(Receiver {
+            chan: self as *const _,
+            drop: |_| {},
+            clone: |_| {},
+            drop_erased: |_| {},
+        })
+    }
+
+    #[cfg(any(test, feature = "alloc"))]
+    pub fn arc_receiver(self: Arc<Self>) -> Option<Receiver<T>> {
+        self.head
+            .state
+            .compare_exchange(0, HAS_RX, AcqRel, Acquire)
+            .ok()?;
+        Some(Receiver::from_arc(self))
+    }
+}
+
+impl<T> Receiver<T> {
+    /// Returns a new one-shot channel receiver, wrapped in an `Arc`.
+    #[cfg(any(test, feature = "alloc"))]
+    #[must_use]
     pub fn new() -> Self {
-        Self {
+        Self::from_arc(Arc::new(Oneshot {
             head: Header {
-                state: AtomicU8::new(IDLE),
+                state: AtomicU8::new(HAS_RX),
                 wait: WaitCell::new(),
             },
-
             cell: UnsafeCell::new(MaybeUninit::uninit()),
+        }))
+    }
+
+    #[cfg(any(test, feature = "alloc"))]
+    fn from_arc(oneshot: Arc<Oneshot<T>>) -> Self {
+        Self {
+            chan: Arc::into_raw(oneshot),
+            drop: Arc::decrement_strong_count,
+            drop_erased: |ptr| unsafe { Arc::decrement_strong_count(ptr.cast::<Oneshot<T>>()) },
+            clone: Arc::increment_strong_count,
         }
     }
 
@@ -359,54 +352,24 @@ impl<T> Receiver<T> {
     /// # }
     /// ```
     #[cfg(any(test, feature = "alloc"))]
-    pub async fn sender(self: &Arc<Self>) -> Result<Sender<T>, SenderError> {
+    pub async fn sender(&self) -> Result<Sender<T>, SenderError> {
         self.take_sender().await?;
+        unsafe { (self.clone)(self.chan) }
         Ok(Sender {
-            chan: Arc::into_raw(self.clone()),
-            drop: Arc::decrement_strong_count,
-            sent: false,
-        })
-    }
-
-    /// Create a [`Sender`] for this channel, using a `static` to store the
-    /// to [store the shared state](../#heap-and-static-storage).
-    ///
-    /// If a [`Sender`] or [`DeserSender`] currently exists and has not been
-    /// used, this method returns a [`SenderError`]. If a message has been sent
-    /// but not received, this method will call [`Receiver::recv`] to receive
-    /// that message, drop it, and then create a new [`Sender`].
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tricky_pipe::oneshot;
-    ///
-    /// static RX: oneshot::Receiver<usize> = oneshot::Receiver::new();
-    /// # #[tokio::main(flavor = "current_thread")] async fn main() {
-    ///
-    /// // because the `Receiver` is stored in a `static`, we can create a
-    /// // `Sender` using the `static_sender` method:
-    /// let tx = RX.static_sender().await.unwrap();
-    ///
-    /// tx.send(1).unwrap();
-    /// assert_eq!(RX.recv().await, Ok(1));
-    /// # }
-    /// ```
-    pub async fn static_sender(&'static self) -> Result<Sender<T>, SenderError> {
-        self.take_sender().await?;
-        Ok(Sender {
-            chan: self as *const Self,
-            drop: |_| {},
+            chan: self.chan,
+            drop: self.drop,
             sent: false,
         })
     }
 
     async fn take_sender(&self) -> Result<(), SenderError> {
-        test_span!("Oneshot::take_sender");
-        while let Err(state) = test_dbg!(self
-            .head
-            .state
-            .compare_exchange(IDLE, HAS_TX, AcqRel, Acquire))
+        test_span!("Oneshot::sender");
+        let this = unsafe { &*self.chan };
+        while let Err(state) =
+            test_dbg!(this
+                .head
+                .state
+                .compare_exchange(HAS_RX, HAS_RX | HAS_TX, AcqRel, Acquire))
         {
             if state & SENT != 0 {
                 let _ = test_dbg!(self.recv().await.map(|_| ()));
@@ -437,8 +400,9 @@ impl<T> Receiver<T> {
     /// Await a message from a [`Sender`] or [`DeserSender`].
     pub fn poll_recv(&self, cx: &mut Context<'_>) -> Poll<Result<T, RecvError>> {
         test_span!("Oneshot::poll_recv");
+        let this = unsafe { &*self.chan };
         loop {
-            let state = test_dbg!(self.head.state.fetch_or(RX_WAITING, AcqRel));
+            let state = test_dbg!(this.head.state.fetch_or(RX_WAITING, AcqRel));
 
             if test_dbg!(state & CLOSED != 0) {
                 return Poll::Ready(Err(RecvError::Closed));
@@ -447,11 +411,11 @@ impl<T> Receiver<T> {
             if test_dbg!(state & SENT != 0) {
                 let mut ret = MaybeUninit::<T>::uninit();
                 unsafe {
-                    self.cell.with_mut(|cell| {
+                    this.cell.with_mut(|cell| {
                         core::ptr::copy_nonoverlapping(cell.cast(), ret.as_mut_ptr(), 1);
                     });
 
-                    test_dbg!(self.head.state.store(IDLE, Release));
+                    test_dbg!(this.head.state.store(HAS_RX, Release));
                     return Poll::Ready(Ok(ret.assume_init()));
                 }
             }
@@ -462,15 +426,16 @@ impl<T> Receiver<T> {
 
             // We are still waiting for the Sender to start or complete.
             // Trigger another wait cycle.
-            task::ready!(test_dbg!(self.head.wait.poll_wait(cx))).map_err(|_| RecvError::Closed)?;
+            task::ready!(test_dbg!(this.head.wait.poll_wait(cx))).map_err(|_| RecvError::Closed)?;
             hint::spin_loop();
         }
     }
 
     /// Close the Oneshot. This will cause any pending senders to fail.
     pub fn close(&self) {
-        if self.head.close() {
-            self.cell
+        let this = unsafe { &*self.chan };
+        if this.head.close() {
+            this.cell
                 .with_mut(|cell| unsafe { core::ptr::drop_in_place(cell.cast::<T>()) });
         }
     }
@@ -479,8 +444,7 @@ impl<T> Receiver<T> {
 impl<T> fmt::Debug for Receiver<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("oneshot::Receiver")
-            .field("head", &self.head)
-            .field("cell", &format_args!("..."))
+            .field("chan", &format_args!("{:p}", self.chan))
             .finish()
     }
 }
@@ -494,7 +458,7 @@ where
             this.vtable
                 .typeinfo
                 .assert_matches::<T>("oneshot::DeserSender");
-            let chan = this.chan.cast::<Receiver<T>>();
+            let chan = this.chan.cast::<Oneshot<T>>();
             (*chan).cell.with_mut(|cell| {
                 core::ptr::drop_in_place(cell.cast::<T>());
             });
@@ -504,7 +468,7 @@ where
                 .typeinfo
                 .assert_matches::<T>("oneshot::DeserSender");
             let val = postcard::from_bytes::<T>(bytes)?;
-            let chan = this.chan.cast::<Receiver<T>>();
+            let chan = this.chan.cast::<Oneshot<T>>();
             unsafe {
                 (*chan).cell.with_mut(|cell| {
                     core::ptr::write(cell.cast::<T>(), val);
@@ -517,7 +481,7 @@ where
                 .typeinfo
                 .assert_matches::<T>("oneshot::DeserSender");
             let val = postcard::from_bytes_cobs::<T>(bytes)?;
-            let chan = this.chan.cast::<Receiver<T>>();
+            let chan = this.chan.cast::<Oneshot<T>>();
             unsafe {
                 (*chan).cell.with_mut(|cell| {
                     core::ptr::write(cell.cast::<T>(), val);
@@ -528,40 +492,21 @@ where
         typeinfo: TypeInfo::of::<T>(),
     };
 
-    /// Create a type-erased, deserializing [`DeserSender`] for this channel,
-    /// using an [`Arc`] allocation to [store the shared
-    /// state](../heap-and-static-storage).
+    /// Create a type-erased, deserializing [`DeserSender`] for this channel, if
+    /// no sender currently exists.
     ///
     /// If a [`Sender`] or [`DeserSender`] currently exists and has not been
     /// used, this method returns a [`SenderError`]. If a message has been sent
     /// but not received, this method will call [`Receiver::recv`] to receive
     /// that message, drop it, and then create a new [` DeserSender`].
-    ///
-    /// This method requires the "alloc" feature flag to be enabled.
-    #[cfg(any(test, feature = "alloc"))]
-    pub async fn deser_sender(self: &Arc<Self>) -> Result<DeserSender, SenderError> {
+    pub async fn deser_sender(&self) -> Result<DeserSender, SenderError> {
         self.take_sender().await?;
+        unsafe {
+            (self.clone)(self.chan);
+        }
         Ok(DeserSender {
-            chan: Arc::into_raw(self.clone()).cast(),
-            drop: Arc::decrement_strong_count,
-            vtable: &Self::VTABLE,
-            sent: false,
-        })
-    }
-
-    /// Create a type-erased, deserializing [`DeserSender`] for this channel,
-    /// using a `static` to store the  to [store the shared
-    /// state](../#heap-and-static-storage).
-    ///
-    /// If a [`Sender`] or [`DeserSender`] currently exists and has not been
-    /// used, this method returns a [`SenderError`]. If a message has been sent
-    /// but not received, this method will call [`Receiver::recv`] to receive
-    /// that message, drop it, and then create a new [`DeserSender`].
-    pub async fn deser_static_sender(&'static self) -> Result<DeserSender, SenderError> {
-        self.take_sender().await?;
-        Ok(DeserSender {
-            chan: self as *const _ as *const Receiver<()>,
-            drop: |_| {},
+            chan: self.chan.cast::<Oneshot<()>>(),
+            drop: self.drop_erased,
             vtable: &Self::VTABLE,
             sent: false,
         })
@@ -655,7 +600,7 @@ impl<T> Sender<T> {
     }
 
     #[inline(always)]
-    fn chan(&self) -> &Receiver<T> {
+    fn chan(&self) -> &Oneshot<T> {
         unsafe { &*self.chan }
     }
 }
@@ -679,7 +624,7 @@ impl<T> fmt::Debug for Sender<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self { drop, sent, .. } = self;
         f.debug_struct("oneshot::Sender")
-            .field("chan", self.chan())
+            // .field("chan", self.chan())
             .field("drop", drop)
             .field("sent", sent)
             .finish()
@@ -796,7 +741,6 @@ unsafe impl Sync for DeserSender {}
 mod tests {
     use super::*;
     use crate::loom::{self, future::block_on, thread};
-    use std::sync::Arc;
 
     #[derive(Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
     pub struct DeserStruct {
@@ -807,7 +751,7 @@ mod tests {
     #[test]
     fn basically_works() {
         loom::model(|| {
-            let rx = Arc::new(Receiver::new());
+            let rx = Receiver::new();
             let tx = block_on(rx.sender()).unwrap();
 
             thread::spawn(move || {
@@ -821,7 +765,7 @@ mod tests {
     #[test]
     fn recv_closed() {
         loom::model(|| {
-            let rx = Arc::new(Receiver::new());
+            let rx = Receiver::new();
             let tx = block_on(rx.sender()).unwrap();
 
             thread::spawn(move || {
@@ -836,7 +780,7 @@ mod tests {
     #[test]
     fn reuse() {
         loom::model(|| {
-            let rx = Arc::new(Receiver::new());
+            let rx = Receiver::new();
 
             let tx = block_on(rx.sender()).unwrap();
             thread::spawn(move || {
@@ -861,7 +805,7 @@ mod tests {
     #[test]
     fn deserialize_tx() {
         loom::model(|| {
-            let rx = Arc::new(Receiver::new());
+            let rx = Receiver::new();
             let tx = block_on(rx.deser_sender()).unwrap();
 
             let value = DeserStruct {


### PR DESCRIPTION
Currently, the `tricky_pipe::oneshot` API allows `Sender`s to be constructed from either an `Arc<Receiver<T>>` or a `&'static Receiver<T>`. This means that in order to use a `Receiver`, it must be _either_ inside an `Arc` _or_ in a `&'static`. This isn't great, as it's difficult for other crates, like MGNP, to write APIs that take a `Receiver<T>` as an argument without caring whether it's in an `Arc` or a `static`.

This branch changes the `oneshot` API so that a `Receiver<T>` is agnostic over the storage type and holds a `*const Oneshot<T>` plus a type-erased `drop` function, like the way `Sender`s currently work. A `Receiver<T>` can now be constructed from either an `Arc<Oneshot<T>>` or a `&'static Oneshot<T>>`. Now, we can write APIs in MGNP that accept a `Receiver<T>`, without caring which storage type is used; this allows the user to pass in whatever oneshot storage they like.