### PR TITLE
feat: implement connection resets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1063,6 +1063,7 @@ dependencies = [
  "loom 0.7.1",
  "maitake-sync",
  "mnemos-bitslab",
+ "mycelium-bitfield 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "portable-atomic",
  "postcard",
  "serde",

--- a/source/mgnp/src/client.rs
+++ b/source/mgnp/src/client.rs
@@ -1,4 +1,7 @@
-use crate::{message::Rejection, registry};
+use crate::{
+    message::{Rejection, Reset},
+    registry,
+};
 use tricky_pipe::{bidi, mpsc, oneshot, serbox};
 
 pub struct Connector<S: registry::Service> {
@@ -25,16 +28,17 @@ pub enum ConnectError {
     Nak(Rejection),
 }
 
-pub type ClientChannel<S> =
-    bidi::BiDi<<S as registry::Service>::ServerMsg, <S as registry::Service>::ClientMsg>;
+pub type ClientChannel<S> = bidi::BiDi<ServerResult<S>, <S as registry::Service>::ClientMsg>;
+
+type ServerResult<S> = Result<<S as registry::Service>::ServerMsg, Reset>;
 
 pub struct Channels<S: registry::Service> {
     srv_chan: bidi::SerBiDi,
-    client_chan: bidi::BiDi<S::ServerMsg, S::ClientMsg>,
+    client_chan: bidi::BiDi<ServerResult<S>, S::ClientMsg>,
 }
 
 pub struct StaticChannels<S: registry::Service, const CAPACITY: usize> {
-    s2c: mpsc::StaticTrickyPipe<S::ServerMsg, CAPACITY>,
+    s2c: mpsc::StaticTrickyPipe<ServerResult<S>, CAPACITY>,
     c2s: mpsc::StaticTrickyPipe<S::ClientMsg, CAPACITY>,
 }
 

--- a/source/mgnp/src/client.rs
+++ b/source/mgnp/src/client.rs
@@ -1,7 +1,4 @@
-use crate::{
-    message::{Rejection, Reset},
-    registry,
-};
+use crate::{message::Rejection, registry};
 use tricky_pipe::{bidi, mpsc, oneshot, serbox};
 
 pub struct Connector<S: registry::Service> {
@@ -28,17 +25,16 @@ pub enum ConnectError {
     Nak(Rejection),
 }
 
-pub type ClientChannel<S> = bidi::BiDi<ServerResult<S>, <S as registry::Service>::ClientMsg>;
-
-type ServerResult<S> = Result<<S as registry::Service>::ServerMsg, Reset>;
+pub type ClientChannel<S> =
+    bidi::BiDi<<S as registry::Service>::ServerMsg, <S as registry::Service>::ClientMsg>;
 
 pub struct Channels<S: registry::Service> {
     srv_chan: bidi::SerBiDi,
-    client_chan: bidi::BiDi<ServerResult<S>, S::ClientMsg>,
+    client_chan: bidi::BiDi<S::ServerMsg, S::ClientMsg>,
 }
 
 pub struct StaticChannels<S: registry::Service, const CAPACITY: usize> {
-    s2c: mpsc::StaticTrickyPipe<ServerResult<S>, CAPACITY>,
+    s2c: mpsc::StaticTrickyPipe<S::ServerMsg, CAPACITY>,
     c2s: mpsc::StaticTrickyPipe<S::ClientMsg, CAPACITY>,
 }
 

--- a/source/mgnp/src/conn_table.rs
+++ b/source/mgnp/src/conn_table.rs
@@ -209,12 +209,6 @@ impl<const CAPACITY: usize> ConnTable<CAPACITY> {
                 self.close(remote_id, Some(reason));
                 None
             }
-            Header::Nak { remote_id, reason } => {
-                tracing::warn!(id.local = %remote_id, ?reason, "process_inbound: NAK");
-                // TODO(eliza): if applicable, tell the local peer that sent the
-                // frame that it was bad...
-                None
-            }
             Header::Reset { remote_id, reason } => {
                 tracing::trace!(id.local = %remote_id, %reason, "process_inbound: RESET");
                 let _closed = self.close(remote_id, None);
@@ -284,7 +278,7 @@ impl<const CAPACITY: usize> ConnTable<CAPACITY> {
                     id.actual_remote = %real_remote_id,
                     "process_ack: socket is not connecting"
                 );
-                Some(OutboundFrame::reset(remote_id, Reset::ConnAlreadyExists))
+                Some(OutboundFrame::reset(remote_id, Reset::YesSuchConn))
             }
             ref mut state @ State::Connecting(_) => {
                 let State::Connecting(rsp) = mem::replace(state, State::Open { remote_id }) else {

--- a/source/mgnp/src/conn_table.rs
+++ b/source/mgnp/src/conn_table.rs
@@ -119,6 +119,12 @@ impl<const CAPACITY: usize> ConnTable<CAPACITY> {
         .await
     }
 
+    pub(crate) async fn reset_all(&mut self) {
+        for entry in self.conns.iter_mut() {
+            if entry
+        }
+    }
+
     fn cleanup_dead(&mut self) {
         // receiving a data frame from the conn table borrows it, so we must
         // remove the dead index from the *previous* next_outbound call before
@@ -241,7 +247,7 @@ impl<const CAPACITY: usize> ConnTable<CAPACITY> {
                 tracing::trace!(id.remote = %local_id, ?identity, "process_inbound: CONNECT");
                 match registry.connect(identity, frame.body).await {
                     Ok(channel) => Some(self.accept(local_id, channel)),
-                    Err(reason) => Some(OutboundFrame::nak(local_id, reason)),
+                    Err(reason) => Some(OutboundFrame::reject(local_id, reason)),
                 }
             }
         }
@@ -342,7 +348,7 @@ impl<const CAPACITY: usize> ConnTable<CAPACITY> {
             // Accepted, we got a local ID!
             Some(local_id) => OutboundFrame::ack(local_id, remote_id),
             // Conn table is full, can't accept this stream.
-            None => OutboundFrame::nak(remote_id, Rejection::ConnTableFull(CAPACITY)),
+            None => OutboundFrame::reject(remote_id, Rejection::ConnTableFull(CAPACITY)),
         }
     }
 

--- a/source/mgnp/src/conn_table.rs
+++ b/source/mgnp/src/conn_table.rs
@@ -6,10 +6,7 @@ use crate::{
 use core::{fmt, mem, num::NonZeroU16, task::Poll};
 use tricky_pipe::{
     bidi::SerBiDi,
-    mpsc::{
-        error::{RecvError, SendError, SerSendError},
-        SerPermit,
-    },
+    mpsc::error::{RecvError, SerSendError},
     oneshot,
 };
 

--- a/source/mgnp/src/conn_table.rs
+++ b/source/mgnp/src/conn_table.rs
@@ -173,7 +173,9 @@ impl<const CAPACITY: usize> ConnTable<CAPACITY> {
                             // TODO(eliza): possibly it would be better if we
                             // just sent the deserialize error to the local peer
                             // and let it decide whether this should kill the
-                            // connection or not? but that's annoying...
+                            // connection or not? maybe by turning the server's
+                            // client-to-server stream into `Result<ClientMsg,
+                            // DecodeError>`s?
                             tracing::debug!(
                                 id.remote = %local_id,
                                 id.local = %id,

--- a/source/mgnp/src/conn_table.rs
+++ b/source/mgnp/src/conn_table.rs
@@ -398,8 +398,7 @@ impl<const CAPACITY: usize> ConnTable<CAPACITY> {
             return false;
         }
 
-        let (_, mut rx) = channel.split();
-        rx.close_with_error(reason)
+        channel.close_with_error(reason)
     }
 
     /// Returns `true` if a connection with the provided ID was closed, `false` if

--- a/source/mgnp/src/conn_table.rs
+++ b/source/mgnp/src/conn_table.rs
@@ -119,12 +119,6 @@ impl<const CAPACITY: usize> ConnTable<CAPACITY> {
         .await
     }
 
-    pub(crate) async fn reset_all(&mut self) {
-        for entry in self.conns.iter_mut() {
-            if entry
-        }
-    }
-
     fn cleanup_dead(&mut self) {
         // receiving a data frame from the conn table borrows it, so we must
         // remove the dead index from the *previous* next_outbound call before

--- a/source/mgnp/src/lib.rs
+++ b/source/mgnp/src/lib.rs
@@ -22,6 +22,9 @@ use futures::FutureExt;
 use message::{InboundFrame, OutboundFrame, Rejection};
 use tricky_pipe::{mpsc, oneshot, serbox};
 
+#[cfg(test)]
+mod tests;
+
 /// A wire-level transport for [MGNP frames](Frame).
 ///
 /// A `Wire` represents a point-to-point link between a local MGNP [`Interface`]
@@ -133,7 +136,7 @@ impl Interface {
     /// [`serbox::Sharer`] and [`oneshot::Receiver`], which may be heap- or
     /// statically-allocated, use the [`Interface::connector_with`] method
     /// instead.
-    #[cfg(feature = "alloc")]
+    #[cfg(any(test, feature = "alloc"))]
     pub fn connector<S: Service>(&self) -> client::Connector<S> {
         self.connector_with(serbox::Sharer::new(), oneshot::Receiver::new())
     }
@@ -207,7 +210,7 @@ where
 
                 // locally-initiated connect request
                 conn = next_conn.fuse() => {
-                    if let Some(conn) = conn {
+                    if let Ok(conn) = conn {
                         out_conn = Some(conn);
                     } else {
                         tracing::info!("connection stream has terminated");

--- a/source/mgnp/src/message.rs
+++ b/source/mgnp/src/message.rs
@@ -153,16 +153,6 @@ pub enum Reset {
     GoAway,
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
-pub enum Nak {
-    /// A frame was rejected because it could not be decoded successfully.
-    DecodeError(DecodeError),
-    /// The local ID sent by the remote does not exist.
-    UnknownLocalId(Id),
-    /// The remote ID sent by the remote does not correspond to an existing stream.
-    UnknownRemoteId(Id),
-}
-
 pub type InboundFrame<'data> = Frame<&'data [u8]>;
 pub type OutboundFrame<'data> = Frame<OutboundData<'data>>;
 

--- a/source/mgnp/src/message.rs
+++ b/source/mgnp/src/message.rs
@@ -159,7 +159,7 @@ pub type OutboundFrame<'data> = Frame<OutboundData<'data>>;
 #[derive(Debug)]
 pub enum OutboundData<'recv> {
     Empty,
-    Data(SerRecvRef<'recv>),
+    Data(SerRecvRef<'recv, Reset>),
     Rejected(serbox::Consumer),
     Hello(serbox::Consumer),
 }
@@ -284,7 +284,7 @@ impl<'bytes, T: Deserialize<'bytes>> Frame<T> {
 }
 
 impl<'data> Frame<OutboundData<'data>> {
-    pub fn data(remote_id: Id, local_id: Id, data: SerRecvRef<'data>) -> Self {
+    pub fn data(remote_id: Id, local_id: Id, data: SerRecvRef<'data, Reset>) -> Self {
         Self {
             header: Header::Data {
                 local_id,

--- a/source/mgnp/src/message.rs
+++ b/source/mgnp/src/message.rs
@@ -111,7 +111,7 @@ pub enum Rejection {
     NotFound,
     /// The connection was rejected by the [`Service`](crate::registry::Service).
     ///
-    /// The body of this [`NAK`](Header::Nak) frame may contain additional bytes
+    /// The body of this [`REJECT`](Header::Reject) frame may contain additional bytes
     /// which can be interpreted as a [service-specific `ConnectError`
     /// value](crate::registry::Service::ConnectError).]
     ServiceRejected,
@@ -304,7 +304,7 @@ impl<'data> Frame<OutboundData<'data>> {
         }
     }
 
-    pub fn nak(remote_id: Id, reason: Rejection) -> Self {
+    pub fn reject(remote_id: Id, reason: Rejection) -> Self {
         Self {
             header: Header::Reject { remote_id, reason },
             body: OutboundData::Empty, // todo

--- a/source/mgnp/src/registry.rs
+++ b/source/mgnp/src/registry.rs
@@ -1,4 +1,4 @@
-use super::Rejection;
+use super::{message::Reset, Rejection};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use tricky_pipe::bidi::SerBiDi;
 use uuid::Uuid;
@@ -16,7 +16,7 @@ pub enum IdentityKind {
 
 /// Represents a mechanism for discovering services on the local node.
 pub trait Registry {
-    async fn connect(&self, identity: Identity, hello: &[u8]) -> Result<SerBiDi, Rejection>;
+    async fn connect(&self, identity: Identity, hello: &[u8]) -> Result<SerBiDi<Reset>, Rejection>;
 }
 
 /// A service definition.

--- a/source/mgnp/src/tests/e2e.rs
+++ b/source/mgnp/src/tests/e2e.rs
@@ -1,7 +1,5 @@
-#![cfg(feature = "alloc")]
-mod support;
-use mgnp::{message::Rejection, registry::Identity};
-use support::*;
+use super::*;
+use crate::{message::Rejection, registry::Identity};
 use svcs::{HelloWorldRequest, HelloWorldResponse};
 
 #[tokio::test]
@@ -25,7 +23,7 @@ async fn basically_works() {
     let rsp = chan.rx().recv().await;
     assert_eq!(
         rsp,
-        Some(HelloWorldResponse {
+        Ok(HelloWorldResponse {
             world: "world".to_string()
         })
     );
@@ -62,7 +60,7 @@ async fn hellos_work() {
     let rsp = chan.rx().recv().await;
     assert_eq!(
         rsp,
-        Some(HelloWorldResponse {
+        Ok(HelloWorldResponse {
             world: "world".to_string()
         })
     );
@@ -112,7 +110,7 @@ async fn nak_bad_hello() {
     let rsp = chan.rx().recv().await;
     assert_eq!(
         rsp,
-        Some(HelloWorldResponse {
+        Ok(HelloWorldResponse {
             world: "world".to_string()
         })
     );
@@ -152,13 +150,13 @@ async fn mux_single_service() {
 
     assert_eq!(
         rsp1,
-        Some(HelloWorldResponse {
+        Ok(HelloWorldResponse {
             world: "world".to_string()
         })
     );
     assert_eq!(
         rsp2,
-        Some(HelloWorldResponse {
+        Ok(HelloWorldResponse {
             world: "world".to_string()
         })
     );
@@ -228,7 +226,7 @@ async fn service_type_routing() {
     let rsp = helloworld_chan.rx().recv().await;
     assert_eq!(
         rsp,
-        Some(HelloWorldResponse {
+        Ok(HelloWorldResponse {
             world: "world".to_string()
         })
     );
@@ -264,7 +262,7 @@ async fn service_type_routing() {
     let rsp = helloworld_chan.rx().recv().await;
     assert_eq!(
         rsp,
-        Some(HelloWorldResponse {
+        Ok(HelloWorldResponse {
             world: "world".to_string()
         })
     );
@@ -272,7 +270,7 @@ async fn service_type_routing() {
     let rsp = hellohello_chan.rx().recv().await;
     assert_eq!(
         rsp,
-        Some(HelloWorldResponse {
+        Ok(HelloWorldResponse {
             world: "world".to_string()
         })
     );
@@ -318,7 +316,7 @@ async fn service_identity_routing() {
     let rsp = sf_conn.rx().recv().await;
     assert_eq!(
         rsp,
-        Some(HelloWorldResponse {
+        Ok(HelloWorldResponse {
             world: "san francisco".to_string()
         })
     );
@@ -346,13 +344,13 @@ async fn service_identity_routing() {
     let (sf_rsp, uni_rsp) = tokio::join! { sf_conn.rx().recv(), uni_conn.rx().recv() };
     assert_eq!(
         sf_rsp,
-        Some(HelloWorldResponse {
+        Ok(HelloWorldResponse {
             world: "san francisco".to_string()
         })
     );
     assert_eq!(
         uni_rsp,
-        Some(HelloWorldResponse {
+        Ok(HelloWorldResponse {
             world: "universe".to_string()
         })
     );

--- a/source/mgnp/src/tests/integration.rs
+++ b/source/mgnp/src/tests/integration.rs
@@ -1,0 +1,186 @@
+use super::*;
+use crate::{
+    message::{self, InboundFrame, OutboundFrame},
+    Wire,
+};
+use tricky_pipe::serbox;
+
+#[tokio::test]
+async fn reset_decode_error() {
+    let remote_registry: TestRegistry = TestRegistry::default();
+    remote_registry.spawn_hello_world();
+
+    let mut fixture = Fixture::new().spawn_remote(remote_registry);
+    let mut wire = fixture.take_local_wire();
+    let mut hellobox = serbox::Sharer::new();
+    let hello = hellobox.share(()).await;
+
+    wire.send(OutboundFrame::connect(
+        crate::Id::new(1),
+        svcs::hello_world_id(),
+        hello,
+    ))
+    .await
+    .unwrap();
+
+    let frame = wire.recv().await.unwrap();
+    let msg = InboundFrame::from_bytes(&frame[..]);
+    assert_eq!(
+        msg,
+        Ok(InboundFrame {
+            header: message::Header::Ack {
+                local_id: crate::Id::new(1),
+                remote_id: crate::Id::new(1),
+            },
+            body: &[]
+        })
+    );
+
+    let mut out_frame = postcard::to_allocvec(&message::Header::Data {
+        local_id: crate::Id::new(1),
+        remote_id: crate::Id::new(1),
+    })
+    .unwrap();
+    out_frame.extend(&[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
+
+    wire.send_bytes(out_frame).await.unwrap();
+
+    let frame = wire.recv().await.unwrap();
+    let msg = InboundFrame::from_bytes(&frame[..]);
+    assert_eq!(
+        msg,
+        Ok(InboundFrame {
+            header: message::Header::Reset {
+                remote_id: crate::Id::new(1),
+                reason: message::Reset::YouDoneGoofed(message::DecodeError::Body(
+                    message::DecodeErrorKind::UnexpectedEnd
+                ))
+            },
+            body: &[]
+        })
+    );
+}
+
+#[tokio::test]
+async fn reset_no_such_conn() {
+    let remote_registry: TestRegistry = TestRegistry::default();
+    remote_registry.spawn_hello_world();
+
+    let mut fixture = Fixture::new().spawn_remote(remote_registry);
+    let mut wire = fixture.take_local_wire();
+    let mut hellobox = serbox::Sharer::new();
+    let hello = hellobox.share(()).await;
+
+    wire.send(OutboundFrame::connect(
+        crate::Id::new(1),
+        svcs::hello_world_id(),
+        hello,
+    ))
+    .await
+    .unwrap();
+
+    let frame = wire.recv().await.unwrap();
+    let msg = InboundFrame::from_bytes(&frame[..]);
+    assert_eq!(
+        msg,
+        Ok(InboundFrame {
+            header: message::Header::Ack {
+                local_id: crate::Id::new(1),
+                remote_id: crate::Id::new(1),
+            },
+            body: &[]
+        })
+    );
+
+    let chan = tricky_pipe::mpsc::TrickyPipe::new(8);
+    let rx = chan.ser_receiver().unwrap();
+    let tx = chan.sender();
+    tx.try_send(svcs::HelloWorldRequest {
+        hello: "hello".into(),
+    })
+    .unwrap();
+
+    let body = rx.try_recv().unwrap();
+
+    let out_frame = {
+        let frame = OutboundFrame {
+            header: message::Header::Data {
+                local_id: crate::Id::new(1),
+                remote_id: crate::Id::new(1), // good conn ID
+            },
+            body: message::OutboundData::Data(body),
+        };
+        frame.to_vec().unwrap()
+    };
+
+    wire.send_bytes(out_frame).await.unwrap();
+
+    let frame = wire.recv().await.unwrap();
+    let msg = InboundFrame::from_bytes(&frame[..]).unwrap();
+    assert_eq!(
+        postcard::from_bytes(msg.body),
+        Ok(svcs::HelloWorldResponse {
+            world: "world".into()
+        })
+    );
+
+    // another message, with a bad conn ID
+    tx.try_send(svcs::HelloWorldRequest {
+        hello: "hello".into(),
+    })
+    .unwrap();
+    let body = rx.try_recv().unwrap();
+    let out_frame = OutboundFrame {
+        header: message::Header::Data {
+            remote_id: crate::Id::new(666), // bad conn ID
+            local_id: crate::Id::new(1),
+        },
+        body: message::OutboundData::Data(body),
+    }
+    .to_vec()
+    .unwrap();
+
+    wire.send_bytes(out_frame).await.unwrap();
+    let frame = wire.recv().await.unwrap();
+    let msg = dbg!(InboundFrame::from_bytes(&frame[..]));
+    assert_eq!(
+        msg,
+        Ok(InboundFrame {
+            header: message::Header::Reset {
+                remote_id: crate::Id::new(1),
+                reason: message::Reset::NoSuchConn,
+            },
+            body: &[]
+        })
+    );
+
+    // another message, with a differently conn ID
+    tx.try_send(svcs::HelloWorldRequest {
+        hello: "hello".into(),
+    })
+    .unwrap();
+    let body = rx.try_recv().unwrap();
+    let out_frame = OutboundFrame {
+        header: message::Header::Data {
+            remote_id: crate::Id::new(1),
+            local_id: crate::Id::new(666), // bad conn ID
+        },
+        body: message::OutboundData::Data(body),
+    }
+    .to_vec()
+    .unwrap();
+
+    wire.send_bytes(out_frame).await.unwrap();
+    let frame = wire.recv().await.unwrap();
+    let msg = dbg!(InboundFrame::from_bytes(&frame[..]));
+    assert_eq!(
+        msg,
+        Ok(InboundFrame {
+            header: message::Header::Reset {
+                remote_id: crate::Id::new(666),
+                reason: message::Reset::NoSuchConn,
+            },
+            body: &[]
+        })
+    );
+}

--- a/source/mgnp/src/tests/mod.rs
+++ b/source/mgnp/src/tests/mod.rs
@@ -1,6 +1,5 @@
-#![cfg(feature = "alloc")]
-use mgnp::{
-    message::{OutboundFrame, Rejection},
+use crate::{
+    message::{OutboundFrame, Rejection, Reset},
     registry::{self, Registry},
     tricky_pipe::{
         bidi::{BiDi, SerBiDi},
@@ -16,9 +15,12 @@ use std::{
 use tokio::sync::{mpsc, oneshot, Notify};
 pub use tracing::Instrument;
 
-pub mod svcs {
+mod e2e;
+mod integration;
+
+pub(crate) mod svcs {
     use super::*;
-    use mgnp::registry;
+    use crate::registry;
     use uuid::{uuid, Uuid};
 
     pub struct HelloWorld;
@@ -88,10 +90,10 @@ pub mod svcs {
         worker: usize,
         req_msg: &'static str,
         rsp_msg: &'static str,
-        chan: BiDi<svcs::HelloWorldRequest, svcs::HelloWorldResponse>,
+        chan: BiDi<svcs::HelloWorldRequest, svcs::HelloWorldResponse, Reset>,
     ) {
         tracing::debug!("hello world worker {worker} running...");
-        while let Some(req) = chan.rx().recv().await {
+        while let Ok(req) = chan.rx().recv().await {
             tracing::info!(?req);
             assert_eq!(req.hello, req_msg);
             chan.tx()
@@ -110,19 +112,19 @@ pub struct Fixture<L, R> {
     test_done: Arc<Notify>,
 }
 
-impl Fixture<TestWire, TestWire> {
+impl Fixture<Option<TestWire>, Option<TestWire>> {
     pub fn new() -> Self {
         Self::default()
     }
 }
 
-impl Default for Fixture<TestWire, TestWire> {
+impl Default for Fixture<Option<TestWire>, Option<TestWire>> {
     fn default() -> Self {
         trace_init();
         let (local, remote) = TestWire::new();
         Self {
-            local,
-            remote,
+            local: Some(local),
+            remote: Some(remote),
             test_done: Arc::new(Notify::new()),
         }
     }
@@ -130,51 +132,69 @@ impl Default for Fixture<TestWire, TestWire> {
 
 type Running = (Interface, tokio::task::JoinHandle<()>);
 
-impl<R> Fixture<TestWire, R> {
-    pub fn spawn_local(self, registry: TestRegistry) -> Fixture<Running, R> {
-        let Fixture {
-            local,
-            remote,
-            test_done,
-        } = self;
-
-        let (iface, machine) = Interface::new::<_, _, { mgnp::DEFAULT_MAX_CONNS }>(
-            local,
+impl<T, E> Fixture<T, E> {
+    fn spawn_peer(
+        name: &'static str,
+        wire: TestWire,
+        registry: TestRegistry,
+        test_done: &Arc<Notify>,
+    ) -> Running {
+        let (iface, machine) = Interface::new::<_, _, { crate::DEFAULT_MAX_CONNS }>(
+            wire,
             registry,
             TrickyPipe::new(8),
         );
+        let task = tokio::spawn(interface("name", machine, test_done.clone()));
+        (iface, task)
+    }
+}
+
+impl<R> Fixture<Option<TestWire>, R> {
+    pub fn spawn_local(self, registry: TestRegistry) -> Fixture<Running, R> {
+        let Fixture {
+            mut local,
+            remote,
+            test_done,
+        } = self;
+        let wire = local
+            .take()
+            .expect("attempted to take the local end of the wire twice!");
         Fixture {
-            local: (
-                iface,
-                tokio::spawn(interface("local", machine, test_done.clone())),
-            ),
+            local: Self::spawn_peer("local", wire, registry, &test_done),
             remote,
             test_done,
         }
     }
+
+    pub fn take_local_wire(&mut self) -> TestWire {
+        self.local
+            .take()
+            .expect("attempted to take the local end of the wire twice!")
+    }
 }
 
-impl<L> Fixture<L, TestWire> {
+impl<L> Fixture<L, Option<TestWire>> {
     pub fn spawn_remote(self, registry: TestRegistry) -> Fixture<L, Running> {
         let Fixture {
             local,
-            remote,
+            mut remote,
             test_done,
         } = self;
 
-        let (iface, machine) = Interface::new::<_, _, { mgnp::DEFAULT_MAX_CONNS }>(
-            remote,
-            registry,
-            TrickyPipe::new(8),
-        );
+        let wire = remote
+            .take()
+            .expect("attempted to take the remote end of the wire twice!");
         Fixture {
             local,
-            remote: (
-                iface,
-                tokio::spawn(interface("remote", machine, test_done.clone())),
-            ),
+            remote: Self::spawn_peer("local", wire, registry, &test_done),
             test_done,
         }
+    }
+
+    pub fn take_remote_wire(&mut self) -> TestWire {
+        self.remote
+            .take()
+            .expect("attempted to take the remote end of the wire twice!")
     }
 }
 
@@ -211,7 +231,7 @@ impl Fixture<Running, Running> {
 #[tracing::instrument(level = tracing::Level::INFO, skip(machine, test_done))]
 async fn interface(
     peer: &'static str,
-    mut machine: mgnp::Machine<TestWire, TestRegistry, { mgnp::DEFAULT_MAX_CONNS }>,
+    mut machine: crate::Machine<TestWire, TestRegistry, { crate::DEFAULT_MAX_CONNS }>,
     test_done: Arc<Notify>,
 ) {
     tokio::select! {
@@ -240,7 +260,7 @@ pub fn trace_init() {
         .try_init();
 }
 
-pub fn make_bidis<In, Out>(cap: u8) -> (SerBiDi, BiDi<In, Out>)
+pub fn make_bidis<In, Out>(cap: u8) -> (SerBiDi<Reset>, BiDi<In, Out, Reset>)
 where
     In: serde::Serialize + serde::de::DeserializeOwned + Send + 'static,
     Out: serde::Serialize + serde::de::DeserializeOwned + Send + 'static,
@@ -277,7 +297,7 @@ pub struct TestFrame(Vec<u8>);
 
 pub struct InboundConnect {
     pub hello: Vec<u8>,
-    pub rsp: oneshot::Sender<Result<SerBiDi, Rejection>>,
+    pub rsp: oneshot::Sender<Result<SerBiDi<Reset>, Rejection>>,
 }
 
 // === impl TestRegistry ===
@@ -288,7 +308,7 @@ impl Registry for TestRegistry {
         &self,
         identity: registry::Identity,
         hello: &[u8],
-    ) -> Result<SerBiDi, Rejection> {
+    ) -> Result<SerBiDi<Reset>, Rejection> {
         let Some(svc) = self.svcs.read().unwrap().get(&identity).cloned() else {
             tracing::info!("REGISTRY: service not found!");
             return Err(Rejection::NotFound);
@@ -372,6 +392,15 @@ impl TestWire {
         let (tx2, rx2) = mpsc::channel(8);
         (Self { tx: tx1, rx: rx2 }, Self { tx: tx2, rx: rx1 })
     }
+
+    pub async fn send_bytes(&mut self, frame: impl Into<Vec<u8>>) -> Result<(), &'static str> {
+        let frame = frame.into();
+        tracing::info!(frame = ?HexSlice::new(&frame), "SEND");
+        self.tx
+            .send(frame)
+            .await
+            .map_err(|_| "the recv end of this wire has been dropped")
+    }
 }
 
 impl Wire for TestWire {
@@ -387,11 +416,7 @@ impl Wire for TestWire {
     async fn send(&mut self, msg: OutboundFrame<'_>) -> Result<(), &'static str> {
         tracing::info!(?msg, "sending message");
         let frame = msg.to_vec().expect("message should serialize");
-        tracing::info!(frame = ?HexSlice::new(&frame), "SEND");
-        self.tx
-            .send(frame)
-            .await
-            .map_err(|_| "the recv end of this wire has been dropped")
+        self.send_bytes(frame).await
     }
 }
 
@@ -424,18 +449,18 @@ impl fmt::Debug for HexSlice<'_> {
 
 #[tracing::instrument(level = tracing::Level::INFO, skip(connector, hello))]
 pub async fn connect_should_nak<S: registry::Service>(
-    connector: &mut mgnp::Connector<S>,
+    connector: &mut crate::Connector<S>,
     name: &'static str,
     hello: S::Hello,
-    nak: mgnp::message::Rejection,
+    nak: crate::message::Rejection,
 ) {
     tracing::info!("connecting to {name} (should NAK)...");
     let res = connector
-        .connect(name, hello, mgnp::client::Channels::new(8))
+        .connect(name, hello, crate::client::Channels::new(8))
         .await;
     tracing::info!(?res, "connect result");
     match res {
-        Err(mgnp::client::ConnectError::Nak(actual)) => assert_eq!(
+        Err(crate::client::ConnectError::Nak(actual)) => assert_eq!(
             actual, nak,
             "expected connection to {name} to be NAK'd with {nak:?}, but it was NAK'd with {actual:?}!"
         ),
@@ -450,13 +475,13 @@ pub async fn connect_should_nak<S: registry::Service>(
 
 #[tracing::instrument(level = tracing::Level::INFO, skip(connector, hello))]
 pub async fn connect<S: registry::Service>(
-    connector: &mut mgnp::Connector<S>,
+    connector: &mut crate::Connector<S>,
     name: &'static str,
     hello: S::Hello,
-) -> mgnp::client::ClientChannel<S> {
+) -> crate::client::Connection<S> {
     tracing::info!("connecting to {name} (should SUCCEED)...");
     let res = connector
-        .connect(name, hello, mgnp::client::Channels::new(8))
+        .connect(name, hello, crate::client::Channels::new(8))
         .await;
     tracing::info!(?res, "connect result");
     match res {

--- a/source/mgnp/tests/integration.rs
+++ b/source/mgnp/tests/integration.rs
@@ -25,9 +25,9 @@ async fn basically_works() {
     let rsp = chan.rx().recv().await;
     assert_eq!(
         rsp,
-        Some(Ok(HelloWorldResponse {
+        Some(HelloWorldResponse {
             world: "world".to_string()
-        }))
+        })
     );
 
     fixture.finish_test().await;
@@ -62,9 +62,9 @@ async fn hellos_work() {
     let rsp = chan.rx().recv().await;
     assert_eq!(
         rsp,
-        Some(Ok(HelloWorldResponse {
+        Some(HelloWorldResponse {
             world: "world".to_string()
-        }))
+        })
     );
 
     fixture.finish_test().await;
@@ -112,9 +112,9 @@ async fn nak_bad_hello() {
     let rsp = chan.rx().recv().await;
     assert_eq!(
         rsp,
-        Some(Ok(HelloWorldResponse {
+        Some(HelloWorldResponse {
             world: "world".to_string()
-        }))
+        })
     );
 
     fixture.finish_test().await;
@@ -152,15 +152,15 @@ async fn mux_single_service() {
 
     assert_eq!(
         rsp1,
-        Some(Ok(HelloWorldResponse {
+        Some(HelloWorldResponse {
             world: "world".to_string()
-        }))
+        })
     );
     assert_eq!(
         rsp2,
-        Some(Ok(HelloWorldResponse {
+        Some(HelloWorldResponse {
             world: "world".to_string()
-        }))
+        })
     );
 
     fixture.finish_test().await;
@@ -228,9 +228,9 @@ async fn service_type_routing() {
     let rsp = helloworld_chan.rx().recv().await;
     assert_eq!(
         rsp,
-        Some(Ok(HelloWorldResponse {
+        Some(HelloWorldResponse {
             world: "world".to_string()
-        }))
+        })
     );
 
     // add the other service
@@ -264,17 +264,17 @@ async fn service_type_routing() {
     let rsp = helloworld_chan.rx().recv().await;
     assert_eq!(
         rsp,
-        Some(Ok(HelloWorldResponse {
+        Some(HelloWorldResponse {
             world: "world".to_string()
-        }))
+        })
     );
 
     let rsp = hellohello_chan.rx().recv().await;
     assert_eq!(
         rsp,
-        Some(Ok(HelloWorldResponse {
+        Some(HelloWorldResponse {
             world: "world".to_string()
-        }))
+        })
     );
 }
 
@@ -318,9 +318,9 @@ async fn service_identity_routing() {
     let rsp = sf_conn.rx().recv().await;
     assert_eq!(
         rsp,
-        Some(Ok(HelloWorldResponse {
+        Some(HelloWorldResponse {
             world: "san francisco".to_string()
-        }))
+        })
     );
 
     // add the 'hello-universe' service
@@ -346,14 +346,14 @@ async fn service_identity_routing() {
     let (sf_rsp, uni_rsp) = tokio::join! { sf_conn.rx().recv(), uni_conn.rx().recv() };
     assert_eq!(
         sf_rsp,
-        Some(Ok(HelloWorldResponse {
+        Some(HelloWorldResponse {
             world: "san francisco".to_string()
-        }))
+        })
     );
     assert_eq!(
         uni_rsp,
-        Some(Ok(HelloWorldResponse {
+        Some(HelloWorldResponse {
             world: "universe".to_string()
-        }))
+        })
     );
 }

--- a/source/mgnp/tests/integration.rs
+++ b/source/mgnp/tests/integration.rs
@@ -25,9 +25,9 @@ async fn basically_works() {
     let rsp = chan.rx().recv().await;
     assert_eq!(
         rsp,
-        Some(HelloWorldResponse {
+        Some(Ok(HelloWorldResponse {
             world: "world".to_string()
-        })
+        }))
     );
 
     fixture.finish_test().await;
@@ -62,9 +62,9 @@ async fn hellos_work() {
     let rsp = chan.rx().recv().await;
     assert_eq!(
         rsp,
-        Some(HelloWorldResponse {
+        Some(Ok(HelloWorldResponse {
             world: "world".to_string()
-        })
+        }))
     );
 
     fixture.finish_test().await;
@@ -112,9 +112,9 @@ async fn nak_bad_hello() {
     let rsp = chan.rx().recv().await;
     assert_eq!(
         rsp,
-        Some(HelloWorldResponse {
+        Some(Ok(HelloWorldResponse {
             world: "world".to_string()
-        })
+        }))
     );
 
     fixture.finish_test().await;
@@ -152,15 +152,15 @@ async fn mux_single_service() {
 
     assert_eq!(
         rsp1,
-        Some(HelloWorldResponse {
+        Some(Ok(HelloWorldResponse {
             world: "world".to_string()
-        })
+        }))
     );
     assert_eq!(
         rsp2,
-        Some(HelloWorldResponse {
+        Some(Ok(HelloWorldResponse {
             world: "world".to_string()
-        })
+        }))
     );
 
     fixture.finish_test().await;
@@ -228,9 +228,9 @@ async fn service_type_routing() {
     let rsp = helloworld_chan.rx().recv().await;
     assert_eq!(
         rsp,
-        Some(HelloWorldResponse {
+        Some(Ok(HelloWorldResponse {
             world: "world".to_string()
-        })
+        }))
     );
 
     // add the other service
@@ -264,17 +264,17 @@ async fn service_type_routing() {
     let rsp = helloworld_chan.rx().recv().await;
     assert_eq!(
         rsp,
-        Some(HelloWorldResponse {
+        Some(Ok(HelloWorldResponse {
             world: "world".to_string()
-        })
+        }))
     );
 
     let rsp = hellohello_chan.rx().recv().await;
     assert_eq!(
         rsp,
-        Some(HelloWorldResponse {
+        Some(Ok(HelloWorldResponse {
             world: "world".to_string()
-        })
+        }))
     );
 }
 
@@ -318,9 +318,9 @@ async fn service_identity_routing() {
     let rsp = sf_conn.rx().recv().await;
     assert_eq!(
         rsp,
-        Some(HelloWorldResponse {
+        Some(Ok(HelloWorldResponse {
             world: "san francisco".to_string()
-        })
+        }))
     );
 
     // add the 'hello-universe' service
@@ -346,14 +346,14 @@ async fn service_identity_routing() {
     let (sf_rsp, uni_rsp) = tokio::join! { sf_conn.rx().recv(), uni_conn.rx().recv() };
     assert_eq!(
         sf_rsp,
-        Some(HelloWorldResponse {
+        Some(Ok(HelloWorldResponse {
             world: "san francisco".to_string()
-        })
+        }))
     );
     assert_eq!(
         uni_rsp,
-        Some(HelloWorldResponse {
+        Some(Ok(HelloWorldResponse {
             world: "universe".to_string()
-        })
+        }))
     );
 }

--- a/source/tricky-pipe/Cargo.toml
+++ b/source/tricky-pipe/Cargo.toml
@@ -25,6 +25,7 @@ alloc = ["postcard/alloc"]
 
 [dependencies]
 maitake-sync = "0.1.0"
+mycelium-bitfield = { version = "0.1.3", default-features = false}
 portable-atomic = "1.4.3"
 mnemos-bitslab = { git = "https://github.com/tosc-rs/mnemos", branch = "eliza/bitslab-loom" }
 futures = { version = "0.3", features = ["async-await"], default-features = false }

--- a/source/tricky-pipe/src/bidi.rs
+++ b/source/tricky-pipe/src/bidi.rs
@@ -55,22 +55,22 @@ where
         (self.tx, self.rx)
     }
 
-    /// Wait until the channel is either ready to send a message *or* a new
-    /// incoming message is received, whichever occurs first.
-    #[must_use]
-    pub async fn wait(&self) -> Option<Event<In, Permit<'_, Out>>> {
-        futures::select_biased! {
-            res = self.tx.reserve().fuse() => {
-                match res {
-                    Ok(permit) => Some(Event::SendReady(permit)),
-                    Err(_) => self.rx.recv().await.map(Event::Recv),
-                }
-            }
-            recv = self.rx.recv().fuse() => {
-                recv.map(Event::Recv)
-            }
-        }
-    }
+    // /// Wait until the channel is either ready to send a message *or* a new
+    // /// incoming message is received, whichever occurs first.
+    // #[must_use]
+    // pub async fn wait(&self) -> Option<Event<In, Permit<'_, Out, ()>>> {
+    //     futures::select_biased! {
+    //         res = self.tx.reserve().fuse() => {
+    //             match res {
+    //                 Ok(permit) => Some(Event::SendReady(permit)),
+    //                 Err(_) => self.rx.recv().await.map(Event::Recv),
+    //             }
+    //         }
+    //         recv = self.rx.recv().fuse() => {
+    //             recv.map(Event::Recv)
+    //         }
+    //     }
+    // }
 
     /// Borrows the **send half** of this bidirectional channel.
     ///
@@ -149,22 +149,22 @@ impl SerBiDi {
         (self.tx, self.rx)
     }
 
-    /// Wait until the channel is either ready to send a message *or* a new
-    /// incoming message is received, whichever occurs first.
-    #[must_use]
-    pub async fn wait(&self) -> Option<Event<SerRecvRef<'_>, SerPermit<'_>>> {
-        futures::select_biased! {
-            res = self.tx.reserve().fuse() => {
-                match res {
-                    Ok(permit) => Some(Event::SendReady(permit)),
-                    Err(_) => self.rx.recv().await.map(Event::Recv),
-                }
-            }
-            recv = self.rx.recv().fuse() => {
-                recv.map(Event::Recv)
-            }
-        }
-    }
+    // /// Wait until the channel is either ready to send a message *or* a new
+    // /// incoming message is received, whichever occurs first.
+    // #[must_use]
+    // pub async fn wait(&self) -> Option<Event<SerRecvRef<'_>, SerPermit<'_, ()>>> {
+    //     futures::select_biased! {
+    //         res = self.tx.reserve().fuse() => {
+    //             match res {
+    //                 Ok(permit) => Some(Event::SendReady(permit)),
+    //                 Err(_) => self.rx.recv().await.map(Event::Recv),
+    //             }
+    //         }
+    //         recv = self.rx.recv().fuse() => {
+    //             recv.map(Event::Recv)
+    //         }
+    //     }
+    // }
 
     /// Borrows the **send half** of this bidirectional channel.
     ///

--- a/source/tricky-pipe/src/mpsc/arc_impl.rs
+++ b/source/tricky-pipe/src/mpsc/arc_impl.rs
@@ -71,10 +71,7 @@ impl<T: 'static, E: Clone + 'static> TrickyPipe<T, E> {
     pub fn receiver(&self) -> Option<Receiver<T, E>> {
         self.0.core.try_claim_rx()?;
 
-        Some(Receiver {
-            pipe: self.typed(),
-            closed_error: false,
-        })
+        Some(Receiver { pipe: self.typed() })
     }
 
     /// Obtain a [`Sender<T>`] capable of sending `T`-typed data
@@ -125,7 +122,6 @@ where
         Some(SerReceiver {
             pipe: self.erased(),
             vtable: Self::SER_VTABLE,
-            closed_error: false,
         })
     }
 

--- a/source/tricky-pipe/src/mpsc/arc_impl.rs
+++ b/source/tricky-pipe/src/mpsc/arc_impl.rs
@@ -11,10 +11,17 @@ use super::channel_core::{Core, CoreVtable};
 // TODO(eliza): we should probably replace the use of `Arc` here with manual ref
 // counting, since the `Core` tracks the number of senders and receivers
 // already. But, I was in a hurry to get a prototype working...
-pub struct TrickyPipe<T: 'static, E: 'static = ()>(Arc<Inner<T, E>>);
+pub struct TrickyPipe<T, E = ()>(Arc<Inner<T, E>>)
+where
+    T: 'static,
+    E: Clone + 'static;
 
-struct Inner<T: 'static, E: 'static> {
-    core: Core<T>,
+struct Inner<T, E>
+where
+    T: 'static,
+    E: Clone + 'static,
+{
+    core: Core<E>,
     // TODO(eliza): instead of boxing the elements array, we should probably
     // manually allocate a `Layout`. This works for now, though.
     //
@@ -26,7 +33,7 @@ struct Inner<T: 'static, E: 'static> {
     elements: Box<[Cell<T>]>,
 }
 
-impl<T: 'static> TrickyPipe<T> {
+impl<T: 'static, E: Clone + 'static> TrickyPipe<T, E> {
     /// Create a new [`TrickyPipe`] allocated on the heap.
     ///
     /// NOTE: `CAPACITY` MUST be a power of two, and must also be <= the number of bits
@@ -49,19 +56,19 @@ impl<T: 'static> TrickyPipe<T> {
         type_name: core::any::type_name::<T>,
     };
 
-    fn erased(&self) -> ErasedPipe {
+    fn erased(&self) -> ErasedPipe<E> {
         let ptr = Arc::into_raw(self.0.clone()) as *const _;
         unsafe { ErasedPipe::new(ptr, Self::CORE_VTABLE) }
     }
 
-    fn typed(&self) -> TypedPipe<T> {
+    fn typed(&self) -> TypedPipe<T, E> {
         unsafe { self.erased().typed() }
     }
     /// Try to obtain a [`Receiver<T>`] capable of receiving `T`-typed data
     ///
     /// This method will only return [`Some`] on the first call. All subsequent calls
     /// will return [`None`].
-    pub fn receiver(&self) -> Option<Receiver<T>> {
+    pub fn receiver(&self) -> Option<Receiver<T, E>> {
         self.0.core.try_claim_rx()?;
 
         Some(Receiver { pipe: self.typed() })
@@ -70,45 +77,46 @@ impl<T: 'static> TrickyPipe<T> {
     /// Obtain a [`Sender<T>`] capable of sending `T`-typed data
     ///
     /// This function may be called multiple times.
-    pub fn sender(&self) -> Sender<T> {
+    pub fn sender(&self) -> Sender<T, E> {
         self.0.core.add_tx();
         Sender { pipe: self.typed() }
     }
 
-    unsafe fn get_core(ptr: *const ()) -> *const Core {
+    unsafe fn get_core(ptr: *const ()) -> *const Core<E> {
         unsafe {
-            let ptr = ptr.cast::<Inner<T>>();
+            let ptr = ptr.cast::<Inner<T, E>>();
             ptr::addr_of!((*ptr).core)
         }
     }
 
     unsafe fn get_elems(ptr: *const ()) -> ErasedSlice {
-        let ptr = ptr.cast::<Inner<T>>();
+        let ptr = ptr.cast::<Inner<T, E>>();
         ErasedSlice::erase(&(*ptr).elements)
     }
 
     unsafe fn erased_clone(ptr: *const ()) {
         test_println!("erased_clone({ptr:p})");
-        Arc::increment_strong_count(ptr.cast::<Inner<T>>())
+        Arc::increment_strong_count(ptr.cast::<Inner<T, E>>())
     }
 
     unsafe fn erased_drop(ptr: *const ()) {
-        let arc = Arc::from_raw(ptr.cast::<Inner<T>>());
+        let arc = Arc::from_raw(ptr.cast::<Inner<T, E>>());
         test_println!(refs = Arc::strong_count(&arc), "erased_drop({ptr:p})");
         drop(arc)
     }
 }
 
-impl<T> TrickyPipe<T>
+impl<T, E> TrickyPipe<T, E>
 where
     T: Serialize + Send + 'static,
+    E: Clone + Send + Sync,
 {
     /// Try to obtain a [`SerReceiver`] capable of receiving bytes containing
     /// a serialized instance of `T`.
     ///
     /// This method will only return [`Some`] on the first call. All subsequent calls
     /// will return [`None`].
-    pub fn ser_receiver(&self) -> Option<SerReceiver> {
+    pub fn ser_receiver(&self) -> Option<SerReceiver<E>> {
         self.0.core.try_claim_rx()?;
 
         Some(SerReceiver {
@@ -128,16 +136,17 @@ where
     };
 }
 
-impl<T> TrickyPipe<T>
+impl<T, E> TrickyPipe<T, E>
 where
     T: DeserializeOwned + Send + 'static,
+    E: Clone + Send + Sync,
 {
     /// Try to obtain a [`DeserSender`] capable of sending bytes containing
     /// a serialized instance of `T`.
     ///
     /// This method will only return [`Some`] on the first call. All subsequent calls
     /// will return [`None`].
-    pub fn deser_sender(&self) -> DeserSender {
+    pub fn deser_sender(&self) -> DeserSender<E> {
         self.0.core.add_tx();
         DeserSender {
             pipe: self.erased(),
@@ -148,7 +157,7 @@ where
     const DESER_VTABLE: &'static DeserVtable = &DeserVtable::new::<T>();
 }
 
-impl<T> Clone for TrickyPipe<T> {
+impl<T, E: Clone> Clone for TrickyPipe<T, E> {
     fn clone(&self) -> Self {
         test_span!("TrickyPipe::clone");
         // Since the `TrickyPipe` type can construct new `Sender`s, this
@@ -160,7 +169,7 @@ impl<T> Clone for TrickyPipe<T> {
     }
 }
 
-impl<T> Drop for TrickyPipe<T> {
+impl<T, E: Clone> Drop for TrickyPipe<T, E> {
     fn drop(&mut self) {
         test_span!("TrickyPipe::drop");
         // Since the `TrickyPipe` type can construct new `Sender`s, this
@@ -171,12 +180,12 @@ impl<T> Drop for TrickyPipe<T> {
     }
 }
 
-unsafe impl<T: Send> Send for TrickyPipe<T> {}
-unsafe impl<T: Send> Sync for TrickyPipe<T> {}
+unsafe impl<T: Send, E: Clone + Send + Sync> Send for TrickyPipe<T, E> {}
+unsafe impl<T: Send, E: Clone + Send + Sync> Sync for TrickyPipe<T, E> {}
 
 // === impl Inner ===
 
-impl<T> Drop for Inner<T> {
+impl<T, E: Clone> Drop for Inner<T, E> {
     fn drop(&mut self) {
         test_span!("Inner::drop");
 

--- a/source/tricky-pipe/src/mpsc/arc_impl.rs
+++ b/source/tricky-pipe/src/mpsc/arc_impl.rs
@@ -71,7 +71,10 @@ impl<T: 'static, E: Clone + 'static> TrickyPipe<T, E> {
     pub fn receiver(&self) -> Option<Receiver<T, E>> {
         self.0.core.try_claim_rx()?;
 
-        Some(Receiver { pipe: self.typed() })
+        Some(Receiver {
+            pipe: self.typed(),
+            closed_error: false,
+        })
     }
 
     /// Obtain a [`Sender<T>`] capable of sending `T`-typed data
@@ -122,6 +125,7 @@ where
         Some(SerReceiver {
             pipe: self.erased(),
             vtable: Self::SER_VTABLE,
+            closed_error: false,
         })
     }
 

--- a/source/tricky-pipe/src/mpsc/arc_impl.rs
+++ b/source/tricky-pipe/src/mpsc/arc_impl.rs
@@ -11,10 +11,10 @@ use super::channel_core::{Core, CoreVtable};
 // TODO(eliza): we should probably replace the use of `Arc` here with manual ref
 // counting, since the `Core` tracks the number of senders and receivers
 // already. But, I was in a hurry to get a prototype working...
-pub struct TrickyPipe<T: 'static>(Arc<Inner<T>>);
+pub struct TrickyPipe<T: 'static, E: 'static = ()>(Arc<Inner<T, E>>);
 
-struct Inner<T: 'static> {
-    core: Core,
+struct Inner<T: 'static, E: 'static> {
+    core: Core<T>,
     // TODO(eliza): instead of boxing the elements array, we should probably
     // manually allocate a `Layout`. This works for now, though.
     //
@@ -41,7 +41,7 @@ impl<T: 'static> TrickyPipe<T> {
         }))
     }
 
-    const CORE_VTABLE: &'static CoreVtable = &CoreVtable {
+    const CORE_VTABLE: &'static CoreVtable<E> = &CoreVtable {
         get_core: Self::get_core,
         get_elems: Self::get_elems,
         clone: Self::erased_clone,

--- a/source/tricky-pipe/src/mpsc/error.rs
+++ b/source/tricky-pipe/src/mpsc/error.rs
@@ -112,8 +112,8 @@ pub enum TryRecvError<E> {
     ///
     /// [`Sender`]: super::Sender
     /// [`DeserSender`]: super::DeserSender
-    /// [`Receiver::try_recv`]: Receiver::try_recv
-    /// [`SerReceiver::try_recv`]: SerReceiver::try_recv
+    /// [`Receiver::try_recv`]: super::Receiver::try_recv
+    /// [`SerReceiver::try_recv`]: super::SerReceiver::try_recv
     Disconnected,
 
     /// A message could not be sent because this channel was closed with an
@@ -126,8 +126,8 @@ pub enum TryRecvError<E> {
     ///
     /// [`Sender::close_with_error`]: super::Sender::close_with_error
     /// [`DeserSender::close_with_error`]: super::DeserSender::close_with_error
-    /// [`Receiver::try_recv`]: Receiver::try_recv
-    /// [`SerReceiver::try_recv`]: SerReceiver::try_recv
+    /// [`Receiver::try_recv`]: super::Receiver::try_recv
+    /// [`SerReceiver::try_recv`]: super::SerReceiver::try_recv
     Error(E),
 }
 

--- a/source/tricky-pipe/src/mpsc/static_impl.rs
+++ b/source/tricky-pipe/src/mpsc/static_impl.rs
@@ -60,10 +60,7 @@ where
     pub fn receiver(&'static self) -> Option<Receiver<T, E>> {
         self.core.try_claim_rx()?;
 
-        Some(Receiver {
-            pipe: self.typed(),
-            closed_error: false,
-        })
+        Some(Receiver { pipe: self.typed() })
     }
 
     /// Obtain a [`Sender<T>`] capable of sending `T`-typed data
@@ -110,7 +107,6 @@ where
         Some(SerReceiver {
             pipe: self.erased(),
             vtable: Self::SER_VTABLE,
-            closed_error: false,
         })
     }
 

--- a/source/tricky-pipe/src/mpsc/static_impl.rs
+++ b/source/tricky-pipe/src/mpsc/static_impl.rs
@@ -60,7 +60,10 @@ where
     pub fn receiver(&'static self) -> Option<Receiver<T, E>> {
         self.core.try_claim_rx()?;
 
-        Some(Receiver { pipe: self.typed() })
+        Some(Receiver {
+            pipe: self.typed(),
+            closed_error: false,
+        })
     }
 
     /// Obtain a [`Sender<T>`] capable of sending `T`-typed data
@@ -107,6 +110,7 @@ where
         Some(SerReceiver {
             pipe: self.erased(),
             vtable: Self::SER_VTABLE,
+            closed_error: false,
         })
     }
 

--- a/source/tricky-pipe/src/mpsc/static_impl.rs
+++ b/source/tricky-pipe/src/mpsc/static_impl.rs
@@ -7,12 +7,16 @@ use super::{
 ///
 /// This variant is intended to be used in static storage on targets
 /// such as embedded systems, where channels are pre-allocated at compile time.
-pub struct StaticTrickyPipe<T: 'static, const CAPACITY: usize> {
+pub struct StaticTrickyPipe<T: 'static, const CAPACITY: usize, E = ()> {
     elements: [Cell<T>; CAPACITY],
-    core: Core,
+    core: Core<E>,
 }
 
-impl<T: 'static, const CAPACITY: usize> StaticTrickyPipe<T, CAPACITY> {
+impl<T, E, const CAPACITY: usize> StaticTrickyPipe<T, CAPACITY, E>
+where
+    T: 'static,
+    E: 'static,
+{
     const EMPTY_CELL: Cell<T> = UnsafeCell::new(MaybeUninit::uninit());
 
     /// Create a new [`StaticTrickyPipe`].
@@ -33,7 +37,7 @@ impl<T: 'static, const CAPACITY: usize> StaticTrickyPipe<T, CAPACITY> {
     /// The maximum possible capacity of a [`StaticTrickyPipe`] on this platform
     pub const MAX_CAPACITY: usize = channel_core::MAX_CAPACITY;
 
-    const CORE_VTABLE: &'static CoreVtable = &CoreVtable {
+    const CORE_VTABLE: &'static CoreVtable<E> = &CoreVtable {
         get_core: Self::get_core,
         get_elems: Self::get_elems,
         clone: Self::erased_clone,
@@ -41,11 +45,11 @@ impl<T: 'static, const CAPACITY: usize> StaticTrickyPipe<T, CAPACITY> {
         type_name: core::any::type_name::<T>,
     };
 
-    fn erased(&'static self) -> ErasedPipe {
+    fn erased(&'static self) -> ErasedPipe<E> {
         unsafe { ErasedPipe::new(self as *const _ as *const (), Self::CORE_VTABLE) }
     }
 
-    fn typed(&'static self) -> TypedPipe<T> {
+    fn typed(&'static self) -> TypedPipe<T, E> {
         unsafe { self.erased().typed() }
     }
 
@@ -53,7 +57,7 @@ impl<T: 'static, const CAPACITY: usize> StaticTrickyPipe<T, CAPACITY> {
     ///
     /// This method will only return [`Some`] on the first call. All subsequent calls
     /// will return [`None`].
-    pub fn receiver(&'static self) -> Option<Receiver<T>> {
+    pub fn receiver(&'static self) -> Option<Receiver<T, E>> {
         self.core.try_claim_rx()?;
 
         Some(Receiver { pipe: self.typed() })
@@ -62,12 +66,12 @@ impl<T: 'static, const CAPACITY: usize> StaticTrickyPipe<T, CAPACITY> {
     /// Obtain a [`Sender<T>`] capable of sending `T`-typed data
     ///
     /// This function may be called multiple times.
-    pub fn sender(&'static self) -> Sender<T> {
+    pub fn sender(&'static self) -> Sender<T, E> {
         self.core.add_tx();
         Sender { pipe: self.typed() }
     }
 
-    fn get_core(ptr: *const ()) -> *const Core {
+    fn get_core(ptr: *const ()) -> *const Core<E> {
         unsafe {
             let ptr = ptr.cast::<Self>();
             ptr::addr_of!((*ptr).core)
@@ -88,7 +92,7 @@ impl<T: 'static, const CAPACITY: usize> StaticTrickyPipe<T, CAPACITY> {
     fn erased_drop(_: *const ()) {}
 }
 
-impl<T, const CAPACITY: usize> StaticTrickyPipe<T, CAPACITY>
+impl<T, E, const CAPACITY: usize> StaticTrickyPipe<T, CAPACITY, E>
 where
     T: Serialize + Send + 'static,
 {
@@ -97,7 +101,7 @@ where
     ///
     /// This method will only return [`Some`] on the first call. All subsequent calls
     /// will return [`None`].
-    pub fn ser_receiver(&'static self) -> Option<SerReceiver> {
+    pub fn ser_receiver(&'static self) -> Option<SerReceiver<E>> {
         self.core.try_claim_rx()?;
 
         Some(SerReceiver {
@@ -117,16 +121,17 @@ where
     };
 }
 
-impl<T, const CAPACITY: usize> StaticTrickyPipe<T, CAPACITY>
+impl<T, E, const CAPACITY: usize> StaticTrickyPipe<T, CAPACITY, E>
 where
     T: DeserializeOwned + Send + 'static,
+    E:,
 {
     /// Try to obtain a [`DeserSender`] capable of sending bytes containing
     /// a serialized instance of `T`.
     ///
     /// This method will only return [`Some`] on the first call. All subsequent calls
     /// will return [`None`].
-    pub fn deser_sender(&'static self) -> DeserSender {
+    pub fn deser_sender(&'static self) -> DeserSender<E> {
         self.core.add_tx();
         DeserSender {
             pipe: self.erased(),
@@ -137,8 +142,18 @@ where
     const DESER_VTABLE: &'static DeserVtable = &DeserVtable::new::<T>();
 }
 
-unsafe impl<T: Send, const CAPACITY: usize> Send for StaticTrickyPipe<T, CAPACITY> {}
-unsafe impl<T: Send, const CAPACITY: usize> Sync for StaticTrickyPipe<T, CAPACITY> {}
+unsafe impl<T, E, const CAPACITY: usize> Send for StaticTrickyPipe<T, CAPACITY, E>
+where
+    T: Send,
+    E: Send,
+{
+}
+unsafe impl<T, E, const CAPACITY: usize> Sync for StaticTrickyPipe<T, CAPACITY, E>
+where
+    T: Send,
+    E: Send,
+{
+}
 
 #[cfg(all(test, not(loom)))]
 mod tests {

--- a/source/tricky-pipe/src/mpsc/static_impl.rs
+++ b/source/tricky-pipe/src/mpsc/static_impl.rs
@@ -238,7 +238,10 @@ mod tests {
         let tx = CHAN.sender();
         let rx = CHAN.receiver().unwrap();
         drop(rx);
-        assert_eq!(tx.try_reserve().unwrap_err(), TrySendError::Closed(()),);
+        assert_eq!(
+            tx.try_reserve().unwrap_err(),
+            TrySendError::Disconnected(()),
+        );
     }
 
     #[test]
@@ -252,7 +255,7 @@ mod tests {
         let tx = CHAN.sender();
         let rx = CHAN.receiver().unwrap();
         drop(tx);
-        assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Closed,);
+        assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Disconnected,);
     }
 
     #[test]
@@ -268,7 +271,7 @@ mod tests {
         let rx = CHAN.receiver().unwrap();
         drop(tx1);
         drop(tx2);
-        assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Closed,);
+        assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Disconnected,);
     }
 
     #[test]
@@ -321,7 +324,10 @@ mod tests {
         let tx = CHAN.sender();
         let rx = CHAN.ser_receiver().unwrap();
         drop(rx);
-        assert_eq!(tx.try_reserve().unwrap_err(), TrySendError::Closed(()));
+        assert_eq!(
+            tx.try_reserve().unwrap_err(),
+            TrySendError::Disconnected(())
+        );
     }
 
     #[test]
@@ -335,7 +341,7 @@ mod tests {
         let tx = CHAN.sender();
         let rx = CHAN.ser_receiver().unwrap();
         drop(tx);
-        assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Closed);
+        assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Disconnected);
     }
 
     #[test]
@@ -351,7 +357,7 @@ mod tests {
         let rx = CHAN.ser_receiver().unwrap();
         drop(tx1);
         drop(tx2);
-        assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Closed);
+        assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Disconnected);
     }
 
     #[test]
@@ -450,10 +456,7 @@ mod tests {
         let rx = CHAN.receiver().unwrap();
         drop(rx);
         let res = tx.try_send([240, 223, 93, 160, 141, 6, 5, 104, 101, 108, 108, 111]);
-        assert_eq!(
-            res.unwrap_err(),
-            SerTrySendError::Send(TrySendError::Closed(())),
-        );
+        assert_eq!(res.unwrap_err(), SerTrySendError::Disconnected,);
     }
 
     #[test]
@@ -467,7 +470,7 @@ mod tests {
         let tx = CHAN.deser_sender();
         let rx = CHAN.receiver().unwrap();
         drop(tx);
-        assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Closed);
+        assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Disconnected);
     }
 
     #[test]
@@ -483,7 +486,7 @@ mod tests {
         let rx = CHAN.receiver().unwrap();
         drop(tx1);
         drop(tx2);
-        assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Closed);
+        assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Disconnected);
     }
 
     #[test]

--- a/source/tricky-pipe/src/mpsc/tests.rs
+++ b/source/tricky-pipe/src/mpsc/tests.rs
@@ -174,7 +174,10 @@ mod single_threaded {
             let tx = test_dbg!(chan.sender());
             let rx = test_dbg!(chan.receiver().unwrap());
             drop(rx);
-            assert_eq!(tx.try_reserve().unwrap_err(), TrySendError::Closed(()),);
+            assert_eq!(
+                tx.try_reserve().unwrap_err(),
+                TrySendError::Disconnected(()),
+            );
         });
     }
 
@@ -186,7 +189,7 @@ mod single_threaded {
             let rx = test_dbg!(chan.receiver().unwrap());
             drop(chan);
             drop(tx);
-            assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Closed,);
+            assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Disconnected,);
         });
     }
 
@@ -200,7 +203,7 @@ mod single_threaded {
             drop(chan);
             drop(tx1);
             drop(tx2);
-            assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Closed,);
+            assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Disconnected,);
         });
     }
 
@@ -257,7 +260,10 @@ mod single_threaded {
             let tx = test_dbg!(chan.sender());
             let rx = test_dbg!(chan.ser_receiver()).unwrap();
             drop(rx);
-            assert_eq!(tx.try_reserve().unwrap_err(), TrySendError::Closed(()));
+            assert_eq!(
+                tx.try_reserve().unwrap_err(),
+                TrySendError::Disconnected(())
+            );
         });
     }
 
@@ -269,7 +275,7 @@ mod single_threaded {
             let rx = test_dbg!(chan.ser_receiver()).unwrap();
             drop(chan);
             drop(tx);
-            assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Closed);
+            assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Disconnected);
         });
     }
 
@@ -283,7 +289,7 @@ mod single_threaded {
             drop(chan);
             drop(tx1);
             drop(tx2);
-            assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Closed);
+            assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Disconnected);
         });
     }
 
@@ -389,10 +395,7 @@ mod single_threaded {
             drop(chan);
             drop(rx);
             let res = tx.try_send([240, 223, 93, 160, 141, 6, 5, 104, 101, 108, 108, 111]);
-            assert_eq!(
-                res.unwrap_err(),
-                SerTrySendError::Send(TrySendError::Closed(())),
-            );
+            assert_eq!(res.unwrap_err(), SerTrySendError::Disconnected,);
         });
     }
 
@@ -404,7 +407,7 @@ mod single_threaded {
             let rx = test_dbg!(chan.receiver()).unwrap();
             drop(chan);
             drop(tx);
-            assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Closed);
+            assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Disconnected);
         });
     }
 
@@ -418,7 +421,7 @@ mod single_threaded {
             drop(chan);
             drop(tx1);
             drop(tx2);
-            assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Closed);
+            assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Disconnected);
         });
     }
 

--- a/source/tricky-pipe/src/mpsc/tests.rs
+++ b/source/tricky-pipe/src/mpsc/tests.rs
@@ -92,16 +92,16 @@ mod trait_impls {
 
     #[test]
     fn permit() {
-        assert_send::<Permit<'_, UnSerStruct>>();
-        assert_sync::<Permit<'_, UnSerStruct>>();
-        assert_unpin::<Permit<'_, UnSerStruct>>();
+        assert_send::<Permit<'_, UnSerStruct, ()>>();
+        assert_sync::<Permit<'_, UnSerStruct, ()>>();
+        assert_unpin::<Permit<'_, UnSerStruct, ()>>();
     }
 
     #[test]
     fn ser_permit() {
-        assert_send::<SerPermit<'_>>();
-        assert_sync::<SerPermit<'_>>();
-        assert_unpin::<SerPermit<'_>>();
+        assert_send::<SerPermit<'_, ()>>();
+        assert_sync::<SerPermit<'_, ()>>();
+        assert_unpin::<SerPermit<'_, ()>>();
     }
 }
 
@@ -505,7 +505,7 @@ fn spsc_try_send_in_capacity() {
 
         future::block_on(async move {
             let mut i = 0;
-            while let Some(msg) = test_dbg!(rx.recv().await) {
+            while let Ok(msg) = test_dbg!(rx.recv().await) {
                 assert_eq!(msg.get_ref(), &i);
                 i += 1;
             }
@@ -532,7 +532,7 @@ fn spsc_send() {
 
         future::block_on(async move {
             let mut i = 0;
-            while let Some(msg) = rx.recv().await {
+            while let Ok(msg) = rx.recv().await {
                 assert_eq!(msg.get_ref(), &i);
                 i += 1;
             }
@@ -565,7 +565,7 @@ fn mpsc_send() {
 
         let recvs = future::block_on(async move {
             let mut recvs = std::collections::BTreeSet::new();
-            while let Some(msg) = rx.recv().await {
+            while let Ok(msg) = rx.recv().await {
                 let msg = msg.into_inner();
                 tracing::info!(received = msg);
                 assert!(


### PR DESCRIPTION
This branch implements connection-level resets, as described in #23. 

In order to implement resets, I've added support for closing a `tricky-pipe` channel with a typed error. Both the sender and receiver can close the channel with an error, and when this occurs, both sides will return that error when receiving/sending. This allows us to easily propagate connection-level resets from the peer to a local client/server when a reset message is received on the wire.

I have *not* implemented global resets on wire-level errors yet. I plan to do that in a subsequent PR.