### PR TITLE
fix(tricky-pipe): mpsc getting stuck when lapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,7 @@ dependencies = [
  "futures",
  "heapless",
  "maitake",
+ "maitake-sync",
  "postcard",
  "proptest",
  "proptest-derive",

--- a/source/tricky-pipe/src/mpsc/tests.rs
+++ b/source/tricky-pipe/src/mpsc/tests.rs
@@ -593,8 +593,9 @@ fn mpsc_send() {
 }
 
 #[test]
-#[cfg_attr(loom, ignore)] // this would probably run for 1000 years under loom...
-fn mpsc_send_full() {
+// this would probably run for 1000 years under loom...
+#[cfg_attr(any(loom, miri), ignore)]
+fn stress_mpsc_send() {
     const TX1_SENDS: usize = 64;
     const TX2_SENDS: usize = 64;
     const SENDS: usize = TX1_SENDS + TX2_SENDS;


### PR DESCRIPTION
This branch fixes an issue where the `tricky-pipe` MPSC can get "stuck" after completing one lap around the queue, due to wrong index management. I've simplified the index bitfields a bit, and added a test reproducing the bug (which, sadly, can't run under loom).