### PR TITLE
feat(tricky-pipe): add `try_cast` to erased tx/rxs

### DIFF
--- a/source/tricky-pipe/src/mpsc/arc_impl.rs
+++ b/source/tricky-pipe/src/mpsc/arc_impl.rs
@@ -61,6 +61,7 @@ impl<T: 'static, E: Clone + 'static> TrickyPipe<T, E> {
         clone: Self::erased_clone,
         drop: Self::erased_drop,
         type_name: core::any::type_name::<T>,
+        type_id: core::any::TypeId::of::<T>,
     };
 
     fn pipe(&self) -> TypedPipe<T, E> {

--- a/source/tricky-pipe/src/mpsc/static_impl.rs
+++ b/source/tricky-pipe/src/mpsc/static_impl.rs
@@ -43,6 +43,7 @@ where
         clone: Self::erased_clone,
         drop: Self::erased_drop,
         type_name: core::any::type_name::<T>,
+        type_id: core::any::TypeId::of::<T>,
     };
 
     fn pipe(&'static self) -> TypedPipe<T, E> {


### PR DESCRIPTION
This commit adds new `SerReceiver::try_cast` and
`DeserSender::try_cast` methods, which attempt to recover a typed `Receiver` or `Sender` from an erased `SerReceiver` or `DeserSender`, respectively. These methods return an error if the requested type does not match the original erased type.