### PR TITLE
feat(tricky-pipe): add `mpsc::ErasedSender`

### DIFF
--- a/source/tricky-pipe/src/bidi.rs
+++ b/source/tricky-pipe/src/bidi.rs
@@ -80,14 +80,14 @@ where
     }
 
     /// Erase the message types of this `BiDi`, returning a [`SerBiDi`].
-    pub fn erase(self) -> SerBiDi<E>
+    pub fn into_serde(self) -> SerBiDi<E>
     where
         In: Serialize + Send + Sync + 'static,
         Out: DeserializeOwned + Send + Sync + 'static,
     {
         SerBiDi {
-            tx: self.tx.erased(),
-            rx: self.rx.erased(),
+            tx: self.tx.into_serde(),
+            rx: self.rx.into_serde(),
             seen_rx_error: self.seen_rx_error,
             seen_tx_error: self.seen_tx_error,
         }

--- a/source/tricky-pipe/src/mpsc/channel_core.rs
+++ b/source/tricky-pipe/src/mpsc/channel_core.rs
@@ -89,7 +89,7 @@ pub(super) struct Reservation<'core, E> {
 /// Erases both a pipe and its element type.
 pub(super) struct ErasedPipe<E: 'static> {
     ptr: *const (),
-    vtable: &'static CoreVtable<E>,
+    pub(super) vtable: &'static CoreVtable<E>,
 }
 
 pub(super) struct TypedPipe<T: 'static, E: 'static> {
@@ -590,7 +590,7 @@ impl ErasedSlice {
         }
     }
 
-    unsafe fn unerase<'a, T: 'static>(self) -> &'a [T] {
+    pub(super) unsafe fn unerase<'a, T: 'static>(self) -> &'a [T] {
         #[cfg(debug_assertions)]
         debug_assert_eq!(
             self.typ,


### PR DESCRIPTION
This branch adds new `ErasedSender` and `ErasedPermit` types to
`tricky_pipe::mpsc`. These types allow senders to reserve channel
capacity for a dynamic type (which may or may not implement `Serialize`
and `DeserializeOwned`), and then dynamically downcast the
`ErasedPermit` back to a concrete type. This allows performing the
asynchronous portion of the send operation (reserving a `Permit`) in a
non-type-erased context, and using a vtable function to actually send
the message once the async reserve operation has completed.